### PR TITLE
Async provider proposal.

### DIFF
--- a/src/Microsoft.AspNet.DependencyInjection/NestedProviders/INestedProvider.cs
+++ b/src/Microsoft.AspNet.DependencyInjection/NestedProviders/INestedProvider.cs
@@ -6,6 +6,6 @@ namespace Microsoft.AspNet.DependencyInjection
     {
         int Order { get; }
 
-        void Invoke(NestedProviderContext<T> context, Action callNext);
+        void Invoke(T context, Action callNext);
     }
 }

--- a/src/Microsoft.AspNet.DependencyInjection/NestedProviders/INestedProviderAsync.cs
+++ b/src/Microsoft.AspNet.DependencyInjection/NestedProviders/INestedProviderAsync.cs
@@ -5,6 +5,6 @@ namespace Microsoft.AspNet.DependencyInjection
 {
     public interface INestedProviderAsync<T> : INestedProvider<T>
     {
-        Task InvokeAsync(NestedProviderContext<T> context, Func<Task> callNext);
+        Task InvokeAsync(T context, Func<Task> callNext);
     }
 }

--- a/src/Microsoft.AspNet.DependencyInjection/NestedProviders/INestedProviderManager.cs
+++ b/src/Microsoft.AspNet.DependencyInjection/NestedProviders/INestedProviderManager.cs
@@ -2,6 +2,6 @@
 {
     interface INestedProviderManager<T>
     {
-        void Invoke(NestedProviderContext<T> context);
+        void Invoke(T context);
     }
 }

--- a/src/Microsoft.AspNet.DependencyInjection/NestedProviders/INestedProviderManagerAsync.cs
+++ b/src/Microsoft.AspNet.DependencyInjection/NestedProviders/INestedProviderManagerAsync.cs
@@ -4,6 +4,6 @@ namespace Microsoft.AspNet.DependencyInjection
 {
     public interface INestedProviderManagerAsync<T>
     {
-        Task InvokeAsync(NestedProviderContext<T> context);
+        Task InvokeAsync(T context);
     }
 }

--- a/src/Microsoft.AspNet.DependencyInjection/NestedProviders/NestedProviderContext.cs
+++ b/src/Microsoft.AspNet.DependencyInjection/NestedProviders/NestedProviderContext.cs
@@ -1,7 +1,0 @@
-﻿namespace Microsoft.AspNet.DependencyInjection
-{
-    public class NestedProviderContext<T>
-    {
-        public T Result { get; set; }
-    }
-}

--- a/src/Microsoft.AspNet.DependencyInjection/NestedProviders/NestedProviderManager.cs
+++ b/src/Microsoft.AspNet.DependencyInjection/NestedProviders/NestedProviderManager.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.AspNet.DependencyInjection.NestedProviders
+{
+    public class NestedProviderManager<T> : INestedProviderManager<T>
+    {
+        private readonly INestedProvider<T>[] _syncProviders;
+
+        public NestedProviderManager(IEnumerable<INestedProvider<T>> providers)
+        {
+            _syncProviders = providers.OrderBy(p => p.Order).ToArray();
+        }
+
+        public void Invoke(T context)
+        {
+            var caller = new CallNext(context, _syncProviders);
+
+            caller.CallNextProvider();
+        }
+
+        private class CallNext
+        {
+            private readonly T _context;
+            private readonly INestedProvider<T>[] _providers;
+            private readonly Action _next;
+
+            private int _index;
+
+            public CallNext(T context, INestedProvider<T>[] providers)
+            {
+                _context = context;
+                _next = CallNextProvider;
+                _providers = providers;
+            }
+
+            public void CallNextProvider()
+            {
+                if (_providers.Length > _index)
+                {
+                    _providers[_index++].Invoke(_context, _next);
+                }
+            }
+        }
+    }
+
+}

--- a/src/Microsoft.AspNet.DependencyInjection/NestedProviders/NestedProviderManagerAsync.cs
+++ b/src/Microsoft.AspNet.DependencyInjection/NestedProviders/NestedProviderManagerAsync.cs
@@ -5,64 +5,31 @@ using System.Threading.Tasks;
 
 namespace Microsoft.AspNet.DependencyInjection.NestedProviders
 {
-    public class NestedProviderManager<T> : INestedProviderManagerAsync<T>, INestedProviderManager<T>
+    public class NestedProviderManagerAsync<T> : INestedProviderManagerAsync<T>
     {
-        private readonly INestedProvider<T>[] _syncProviders;
         private readonly INestedProviderAsync<T>[] _asyncProviders;
 
-        public NestedProviderManager(IEnumerable<INestedProvider<T>> providers, IEnumerable<INestedProviderAsync<T>> asyncProviders)
+        public NestedProviderManagerAsync(IEnumerable<INestedProviderAsync<T>> asyncProviders)
         {
-            _syncProviders = providers.OrderBy(p => p.Order).ToArray();
             _asyncProviders = asyncProviders.OrderBy(p => p.Order).ToArray();
         }
 
-        public void Invoke(NestedProviderContext<T> context)
-        {
-            var caller = new CallNext(context, _syncProviders);
-
-            caller.CallNextProvider();
-        }
-
-        public async Task InvokeAsync(NestedProviderContext<T> context)
+        public async Task InvokeAsync(T context)
         {
             var caller = new CallNextAsync(context, _asyncProviders);
 
             await caller.CallNextProvider();
         }
 
-        private class CallNext
-        {
-            private readonly NestedProviderContext<T> _context;
-            private readonly INestedProvider<T>[] _providers;
-            private readonly Action _next;
-
-            private int _index;
-
-            public CallNext(NestedProviderContext<T> context, INestedProvider<T>[] providers)
-            {
-                _context = context;
-                _next = CallNextProvider;
-                _providers = providers;
-            }
-
-            public void CallNextProvider()
-            {
-                if (_providers.Length > _index)
-                {
-                    _providers[_index++].Invoke(_context, _next);
-                }
-            }
-        }
-
         private class CallNextAsync
         {
-            private readonly NestedProviderContext<T> _context;
+            private readonly T _context;
             private readonly INestedProviderAsync<T>[] _providers;
             private readonly Func<Task> _next;
 
             private int _index;
 
-            public CallNextAsync(NestedProviderContext<T> context, INestedProviderAsync<T>[] providers)
+            public CallNextAsync(T context, INestedProviderAsync<T>[] providers)
             {
                 _context = context;
                 _next = CallNextProvider;


### PR DESCRIPTION
Note the diff it between the sync to the async (see other PR for initial sync proposal)

The pattern suggested is:
1. providers register as sync or async
2. There is a single default manager, the invokeasync runs only providers registered for async, and similarly the sync call does the same.

Potentially the sync call can merge the async providers as well and call the sync method,
and the async call do the same. I can be persuaded to go that way.
