### PR TITLE
Static DefaultServiceProvider.Create

### DIFF
--- a/src/Microsoft.AspNet.DependencyInjection/DefaultServiceProvider.cs
+++ b/src/Microsoft.AspNet.DependencyInjection/DefaultServiceProvider.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNet.DependencyInjection
+{
+    public static class DefaultServiceProvider
+    {
+        public static IServiceProvider Create(
+                IServiceProvider wrappedProvider,
+                IEnumerable<IServiceDescriptor> descriptors)
+        {
+            var provider = new ServiceProvider(wrappedProvider);
+            return provider.Add(descriptors);
+        }
+    }
+}


### PR DESCRIPTION
- Requires an IServiceProvider to be wrapped
- Eventually ServiceProvider won't be public so this should be used instead
