### PR TITLE
Throw when attempting to resolve unregistered services

### DIFF
--- a/src/Microsoft.Framework.DependencyInjection.Ninject/NinjectServiceProvider.cs
+++ b/src/Microsoft.Framework.DependencyInjection.Ninject/NinjectServiceProvider.cs
@@ -36,7 +36,10 @@ namespace Microsoft.Framework.DependencyInjection.Ninject
 
         public object GetService(Type type)
         {
-            return GetSingleService(type) ?? GetLast(GetAll(type)) ?? GetMultiService(type);
+            return GetSingleService(type) ??
+                GetLast(GetAll(type)) ??
+                GetMultiService(type) ??
+                _resolver.Get(type);
         }
 
         private object GetSingleService(Type type)

--- a/src/Microsoft.Framework.DependencyInjection.Ninject/NinjectServiceProvider.cs
+++ b/src/Microsoft.Framework.DependencyInjection.Ninject/NinjectServiceProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Framework.DependencyInjection.Ninject
             if (collectionTypeInfo.IsGenericType &&
                 collectionTypeInfo.GetGenericTypeDefinition() == typeof(IEnumerable<>))
             {
-                var serviceType = collectionType.GetTypeInfo().GenericTypeArguments.Single();
+                var serviceType = collectionTypeInfo.GenericTypeArguments.Single();
                 return GetAll(serviceType);
             }
 

--- a/src/Microsoft.Framework.DependencyInjection/ActivatorUtilities.cs
+++ b/src/Microsoft.Framework.DependencyInjection/ActivatorUtilities.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Framework.DependencyInjection
         /// </summary>
         /// <param name="type"></param>
         /// <returns></returns>
+        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "IServiceProvider may throw unknown exceptions")]
         public static Func<IServiceProvider, object> CreateFactory(Type type)
         {
             if (type == null)
@@ -84,7 +85,17 @@ namespace Microsoft.Framework.DependencyInjection
                     var args = new object[parameters.Length];
                     for (int index = 0; index != parameters.Length; ++index)
                     {
-                        args[index] = services.GetService(parameters[index].ParameterType);
+                        try
+                        {
+                            args[index] = services.GetService(parameters[index].ParameterType);
+                        }
+                        catch (Exception innerException)
+                        {
+                            throw new Exception(
+                                string.Format("TODO: Unable to resolve service for type '{0}' while attempting to activate '{1}'.",
+                                    parameters[index].ParameterType, type),
+                                innerException);
+                        }
                     }
                     return Activator.CreateInstance(type, args);
                 };

--- a/src/Microsoft.Framework.DependencyInjection/ServiceLookup/Service.cs
+++ b/src/Microsoft.Framework.DependencyInjection/ServiceLookup/Service.cs
@@ -27,9 +27,7 @@ namespace Microsoft.Framework.DependencyInjection.ServiceLookup
             }
             else
             {
-                var serviceFactory =
-                    ActivatorUtilities.CreateFactory(_descriptor.ImplementationType);
-                return serviceFactory(provider);
+                return ActivatorUtilities.CreateInstance(provider, _descriptor.ImplementationType);
             }
         }
     }

--- a/test/Microsoft.Framework.DependencyInjection.Tests/Fakes/DependOnNonexistentService.cs
+++ b/test/Microsoft.Framework.DependencyInjection.Tests/Fakes/DependOnNonexistentService.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Framework.DependencyInjection.Tests.Fakes
+{
+    public class DependOnNonexistentService : IDependOnNonexistentService
+    {
+        public DependOnNonexistentService(INonexistentService nonExistentService)
+        {
+        }
+    }
+}

--- a/test/Microsoft.Framework.DependencyInjection.Tests/Fakes/FakeNonScopingFallbackServiceProvder.cs
+++ b/test/Microsoft.Framework.DependencyInjection.Tests/Fakes/FakeNonScopingFallbackServiceProvder.cs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 
 namespace Microsoft.Framework.DependencyInjection.Tests.Fakes
 {
@@ -9,9 +12,21 @@ namespace Microsoft.Framework.DependencyInjection.Tests.Fakes
     {
         public object GetService(Type serviceType)
         {
+            var typeInfo = serviceType.GetTypeInfo();
+
             if (serviceType == typeof(string))
             {
                 return "FakeNonScopingFallbackServiceProvder";
+            }
+            if (serviceType == typeof(IEnumerable<string>))
+            {
+                return new[] { "FakeNonScopingFallbackServiceProvder" };
+            }
+            if (typeInfo.IsGenericType &&
+                typeInfo.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+            {
+                var innerType = typeInfo.GenericTypeArguments.Single();
+                return Array.CreateInstance(innerType, 0);
             }
             else
             {

--- a/test/Microsoft.Framework.DependencyInjection.Tests/Fakes/IDependOnNonexistentService.cs
+++ b/test/Microsoft.Framework.DependencyInjection.Tests/Fakes/IDependOnNonexistentService.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Framework.DependencyInjection.Tests.Fakes
+{
+    public interface IDependOnNonexistentService
+    {
+    }
+}

--- a/test/Microsoft.Framework.DependencyInjection.Tests/Fakes/INonexistentService.cs
+++ b/test/Microsoft.Framework.DependencyInjection.Tests/Fakes/INonexistentService.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Framework.DependencyInjection.Tests.Fakes
+{
+    public interface INonexistentService
+    {
+    }
+}

--- a/test/Microsoft.Framework.DependencyInjection.Tests/Fakes/TestServices.cs
+++ b/test/Microsoft.Framework.DependencyInjection.Tests/Fakes/TestServices.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Framework.DependencyInjection.Tests.Fakes
             yield return describer.Scoped<IFakeScopedService, FakeService>();
             yield return describer.Singleton<IFakeSingletonService, FakeService>();
             yield return describer.Transient<IFakeFallbackService, FakeService>();
+            yield return describer.Transient<IDependOnNonexistentService, DependOnNonexistentService>();
             yield return describer.Describe(
                 typeof(IFakeOpenGenericService<string>),
                 typeof(FakeService),

--- a/test/Microsoft.Framework.DependencyInjection.Tests/Microsoft.Framework.DependencyInjection.Tests.kproj
+++ b/test/Microsoft.Framework.DependencyInjection.Tests/Microsoft.Framework.DependencyInjection.Tests.kproj
@@ -25,11 +25,13 @@
     <Compile Include="Fakes\AnotherClass.cs" />
     <Compile Include="Fakes\AnotherClassAcceptingData.cs" />
     <Compile Include="Fakes\ClassWithStaticCtor.cs" />
+    <Compile Include="Fakes\DependOnNonexistentService.cs" />
     <Compile Include="Fakes\FakeFallbackServiceProvider.cs" />
     <Compile Include="Fakes\FakeNonScopingFallbackServiceProvder.cs" />
     <Compile Include="Fakes\FakeOpenGenericService.cs" />
     <Compile Include="Fakes\FakeOuterService.cs" />
     <Compile Include="Fakes\FakeService.cs" />
+    <Compile Include="Fakes\IDependOnNonexistentService.cs" />
     <Compile Include="Fakes\IFakeEveryService.cs" />
     <Compile Include="Fakes\IFakeMultipleService.cs" />
     <Compile Include="Fakes\IFakeOpenGenericService.cs" />
@@ -38,6 +40,7 @@
     <Compile Include="Fakes\IFakeService.cs" />
     <Compile Include="Fakes\IFakeServiceInstance.cs" />
     <Compile Include="Fakes\IFakeSingletonService.cs" />
+    <Compile Include="Fakes\INonexistentService.cs" />
     <Compile Include="Fakes\IReplaceFallbackService.cs" />
     <Compile Include="Fakes\TestServices.cs" />
     <Compile Include="NinjectContainerTests.cs" />

--- a/test/Microsoft.Framework.DependencyInjection.Tests/ScopingContainerTestBase.cs
+++ b/test/Microsoft.Framework.DependencyInjection.Tests/ScopingContainerTestBase.cs
@@ -279,5 +279,23 @@ namespace Microsoft.Framework.DependencyInjection.Tests
             Assert.ThrowsAny<Exception>(() =>
                 container.GetService<IEnumerable<IDependOnNonexistentService>>().ToArray());
         }
+
+        [Fact]
+        public void AttemptingToResolveNonexistentServiceUsingGetServiceOrDefaultReturnsNull()
+        {
+            var container = CreateContainer(fallbackProvider: null);
+
+            var service = container.GetServiceOrDefault<INonexistentService>();
+
+            Assert.Null(service);
+        }
+
+        [Fact]
+        public void AttemptingToResolveNonexistentServiceIndirectlyUsingGetServiceOrDefaultThrows()
+        {
+            var container = CreateContainer(fallbackProvider: null);
+
+            Assert.ThrowsAny<Exception>(() => container.GetServiceOrDefault<IDependOnNonexistentService>());
+        }
     }
 }

--- a/test/Microsoft.Framework.DependencyInjection.Tests/ScopingContainerTestBase.cs
+++ b/test/Microsoft.Framework.DependencyInjection.Tests/ScopingContainerTestBase.cs
@@ -243,5 +243,41 @@ namespace Microsoft.Framework.DependencyInjection.Tests
 
             Assert.Equal("FakeServiceSimpleMethod", service.SimpleMethod());
         }
+
+        [Fact]
+        public void AttemptingToResolveNonexistentServiceThrows()
+        {
+            var container = CreateContainer(fallbackProvider: null);
+
+            Assert.ThrowsAny<Exception>(() => container.GetService<INonexistentService>());
+        }
+
+        [Fact]
+        public void AttemptingToResolveNonexistentServiceIndirectlyThrows()
+        {
+            var container = CreateContainer(fallbackProvider: null);
+
+            Assert.ThrowsAny<Exception>(() => container.GetService<IDependOnNonexistentService>());
+        }
+
+        [Fact]
+        public void NonexistentServiceCanBeIEnumerableResolved()
+        {
+            var container = CreateContainer(fallbackProvider: null);
+
+            var services = container.GetService<IEnumerable<INonexistentService>>();
+
+            Assert.Empty(services);
+        }
+
+        [Fact]
+        public void AttemptingToIEnumerableResolveNonexistentServiceIndirectlyThrows()
+        {
+            var container = CreateContainer(fallbackProvider: null);
+
+            // The call to ToArray is necessary for Ninject to throw
+            Assert.ThrowsAny<Exception>(() =>
+                container.GetService<IEnumerable<IDependOnNonexistentService>>().ToArray());
+        }
     }
 }


### PR DESCRIPTION
- Ninject and Autofac already exhibited the correct behavior.
- We needed to make our ServiceProvider throw instead of returning null.
- We also needed to make our NinjectServiceProvider throw.
#78
