### PR TITLE
Refactoring ServiceCollection

### DIFF
--- a/src/Microsoft.Framework.DependencyInjection/IServiceCollection.cs
+++ b/src/Microsoft.Framework.DependencyInjection/IServiceCollection.cs
@@ -1,32 +1,30 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Framework.DependencyInjection
 {
+    /// <summary>
+    /// Specifies the contract for a collection of service descriptors.
+    /// </summary>
 #if ASPNET50 || ASPNETCORE50
     [Microsoft.Framework.Runtime.AssemblyNeutral]
 #endif
     public interface IServiceCollection : IEnumerable<IServiceDescriptor>
     {
+        /// <summary>
+        /// Adds the <paramref name="descriptor"/> to this instance.
+        /// </summary>
+        /// <param name="descriptor">The <see cref="IServiceDescriptor"/> to add.</param>
+        /// <returns>A reference to the current instance of <see cref="IServiceCollection"/>.</returns>
         IServiceCollection Add(IServiceDescriptor descriptor);
 
+        /// <summary>
+        /// Adds a sequence of <see cref="IServiceDescriptor"/> to this instance.
+        /// </summary>
+        /// <param name="descriptor">The <see cref="IEnumerable{T}"/> of <see cref="IServiceDescriptor"/>s to add.</param>
+        /// <returns>A reference to the current instance of <see cref="IServiceCollection"/>.</returns>
         IServiceCollection Add(IEnumerable<IServiceDescriptor> descriptors);
-
-        IServiceCollection AddTransient(Type service, Type implementationType);
-
-        IServiceCollection AddTransient(Type service, Func<IServiceProvider, object> implementationFactory);
-
-        IServiceCollection AddScoped(Type service, Type implementationType);
-
-        IServiceCollection AddScoped(Type service, Func<IServiceProvider, object> implementationFactory);
-
-        IServiceCollection AddSingleton(Type service, Type implementationType);
-
-        IServiceCollection AddSingleton(Type service, Func<IServiceProvider, object> implementationFactory);
-
-        IServiceCollection AddInstance(Type service, object implementationInstance);
     }
 }

--- a/src/Microsoft.Framework.DependencyInjection/ServiceCollection.cs
+++ b/src/Microsoft.Framework.DependencyInjection/ServiceCollection.cs
@@ -1,80 +1,33 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
-using Microsoft.Framework.ConfigurationModel;
 
 namespace Microsoft.Framework.DependencyInjection
 {
+    /// <summary>
+    /// Default implementation of <see cref="IServiceCollection"/>.
+    /// </summary>
     public class ServiceCollection : IServiceCollection
     {
-        private readonly List<IServiceDescriptor> _descriptors;
-        private readonly ServiceDescriber _describe;
+        private readonly List<IServiceDescriptor> _descriptors = new List<IServiceDescriptor>();
 
-        public ServiceCollection()
-            : this(new Configuration())
-        {
-        }
-
-        public ServiceCollection(IConfiguration configuration)
-        {
-            _descriptors = new List<IServiceDescriptor>();
-            _describe = new ServiceDescriber(configuration);
-        }
-
+        /// <inheritdoc />
         public IServiceCollection Add(IServiceDescriptor descriptor)
         {
             _descriptors.Add(descriptor);
             return this;
         }
 
+        /// <inheritdoc />
         public IServiceCollection Add(IEnumerable<IServiceDescriptor> descriptors)
         {
             _descriptors.AddRange(descriptors);
             return this;
         }
 
-        public IServiceCollection AddTransient(Type service, Type implementationType)
-        {
-            Add(_describe.Transient(service, implementationType));
-            return this;
-        }
-
-        public IServiceCollection AddTransient(Type service, Func<IServiceProvider, object> implementationFactory)
-        {
-            return Add(_describe.Transient(service, implementationFactory));
-        }
-
-        public IServiceCollection AddScoped(Type service, Type implementationType)
-        {
-            Add(_describe.Scoped(service, implementationType));
-            return this;
-        }
-
-        public IServiceCollection AddScoped(Type service, Func<IServiceProvider, object> implementationFactory)
-        {
-            return Add(_describe.Scoped(service, implementationFactory));
-        }
-
-        public IServiceCollection AddSingleton(Type service, Type implementationType)
-        {
-            Add(_describe.Singleton(service, implementationType));
-            return this;
-        }
-
-        public IServiceCollection AddInstance(Type service, object implementationInstance)
-        {
-            Add(_describe.Instance(service, implementationInstance));
-            return this;
-        }
-
-        public IServiceCollection AddSingleton(Type service, Func<IServiceProvider, object> implementationFactory)
-        {
-            return Add(_describe.Singleton(service, implementationFactory));
-        }
-
+        /// <inheritdoc />
         public IEnumerator<IServiceDescriptor> GetEnumerator()
         {
             return _descriptors.GetEnumerator();

--- a/src/Microsoft.Framework.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Framework.DependencyInjection/ServiceCollectionExtensions.cs
@@ -7,17 +7,68 @@ namespace Microsoft.Framework.DependencyInjection
 {
     public static class ServiceCollectionExtensions
     {
-        public static IServiceCollection AddTransient<TService, TImplementation>([NotNull]this IServiceCollection services)
+        public static IServiceCollection AddTransient([NotNull] this IServiceCollection collection, 
+                                                      [NotNull] Type service, 
+                                                      [NotNull] Type implementationType)
+        {
+            return Add(collection, service, implementationType, LifecycleKind.Transient);
+        }
+
+        public static IServiceCollection AddTransient([NotNull] this IServiceCollection collection,
+                                                      [NotNull] Type service, 
+                                                      [NotNull] Func<IServiceProvider, object> implementationFactory)
+        {
+            return Add(collection, service, implementationFactory, LifecycleKind.Transient);
+        }
+
+        public static IServiceCollection AddScoped([NotNull] this IServiceCollection collection,
+                                                   [NotNull] Type service,
+                                                   [NotNull] Type implementationType)
+        {
+            return Add(collection, service, implementationType, LifecycleKind.Scoped);
+        }
+
+        public static IServiceCollection AddScoped([NotNull] this IServiceCollection collection,
+                                                   [NotNull] Type service,
+                                                   [NotNull] Func<IServiceProvider, object> implementationFactory)
+        {
+            return Add(collection, service, implementationFactory, LifecycleKind.Scoped);
+        }
+
+        public static IServiceCollection AddSingleton([NotNull] this IServiceCollection collection,
+                                                      [NotNull] Type service,
+                                                      [NotNull] Type implementationType)
+        {
+            return Add(collection, service, implementationType, LifecycleKind.Singleton);
+        }
+
+        public static IServiceCollection AddSingleton([NotNull] this IServiceCollection collection,
+                                                      [NotNull] Type service,
+                                                      [NotNull] Func<IServiceProvider, object> implementationFactory)
+        {
+            return Add(collection, service, implementationFactory, LifecycleKind.Singleton);
+        }
+
+        public static IServiceCollection AddInstance([NotNull] this IServiceCollection collection,
+                                                     [NotNull] Type service,
+                                                     [NotNull] object implementationInstance)
+        {
+            var serviceDescriptor = new ServiceDescriptor(service, implementationInstance);
+            return collection.Add(serviceDescriptor);
+        }
+
+        public static IServiceCollection AddTransient<TService, TImplementation>([NotNull] this IServiceCollection services)
         {
             return services.AddTransient(typeof(TService), typeof(TImplementation));
         }
 
-        public static IServiceCollection AddTransient([NotNull]this IServiceCollection services, Type serviceType)
+        public static IServiceCollection AddTransient([NotNull] this IServiceCollection services,
+                                                      [NotNull] Type serviceType)
         {
             return services.AddTransient(serviceType, serviceType);
         }
 
-        public static IServiceCollection AddTransient<TService>([NotNull]this IServiceCollection services)
+        public static IServiceCollection AddTransient<TService>([NotNull] this IServiceCollection services)
         {
             return services.AddTransient(typeof(TService));
         }
@@ -28,12 +79,13 @@ namespace Microsoft.Framework.DependencyInjection
             return services.AddTransient(typeof(TService), implementationFactory);
         }
 
-        public static IServiceCollection AddScoped<TService, TImplementation>([NotNull]this IServiceCollection services)
+        public static IServiceCollection AddScoped<TService, TImplementation>([NotNull] this IServiceCollection services)
         {
             return services.AddScoped(typeof(TService), typeof(TImplementation));
         }
 
-        public static IServiceCollection AddScoped([NotNull]this IServiceCollection services, Type serviceType)
+        public static IServiceCollection AddScoped([NotNull] this IServiceCollection services,
+                                                   [NotNull] Type serviceType)
         {
             return services.AddScoped(serviceType, serviceType);
         }
@@ -44,22 +96,23 @@ namespace Microsoft.Framework.DependencyInjection
             return services.AddScoped(typeof(TService), implementationFactory);
         }
 
-        public static IServiceCollection AddScoped<TService>([NotNull]this IServiceCollection services)
+        public static IServiceCollection AddScoped<TService>([NotNull] this IServiceCollection services)
         {
             return services.AddScoped(typeof(TService));
         }
 
-        public static IServiceCollection AddSingleton<TService, TImplementation>([NotNull]this IServiceCollection services)
+        public static IServiceCollection AddSingleton<TService, TImplementation>([NotNull] this IServiceCollection services)
         {
             return services.AddSingleton(typeof(TService), typeof(TImplementation));
         }
 
-        public static IServiceCollection AddSingleton([NotNull]this IServiceCollection services, Type serviceType)
+        public static IServiceCollection AddSingleton([NotNull] this IServiceCollection services, 
+                                                      [NotNull] Type serviceType)
         {
             return services.AddSingleton(serviceType, serviceType);
         }
 
-        public static IServiceCollection AddSingleton<TService>([NotNull]this IServiceCollection services)
+        public static IServiceCollection AddSingleton<TService>([NotNull] this IServiceCollection services)
         {
             return services.AddSingleton(typeof(TService));
         }
@@ -70,9 +123,29 @@ namespace Microsoft.Framework.DependencyInjection
             return services.AddSingleton(typeof(TService), implementationFactory);
         }
 
-        public static IServiceCollection AddInstance<TService>([NotNull]this IServiceCollection services, TService implementationInstance)
+        public static IServiceCollection AddInstance<TService>([NotNull] this IServiceCollection services, 
+                                                               [NotNull] TService implementationInstance)
+            where TService : class
         {
             return services.AddInstance(typeof(TService), implementationInstance);
+        }
+
+        private static IServiceCollection Add(IServiceCollection collection,
+                                              Type service,
+                                              Type implementationType,
+                                              LifecycleKind lifeCycle)
+        {
+            var descriptor = new ServiceDescriptor(service, implementationType, lifeCycle);
+            return collection.Add(descriptor);
+        }
+
+        private static IServiceCollection Add(IServiceCollection collection,
+                                              Type service,
+                                              Func<IServiceProvider, object> implementationFactory,
+                                              LifecycleKind lifeCycle)
+        {
+            var descriptor = new ServiceDescriptor(service, implementationFactory, lifeCycle);
+            return collection.Add(descriptor);
         }
     }
 }

--- a/src/Microsoft.Framework.DependencyInjection/ServiceDescriptor.cs
+++ b/src/Microsoft.Framework.DependencyInjection/ServiceDescriptor.cs
@@ -13,7 +13,9 @@ namespace Microsoft.Framework.DependencyInjection
         /// <param name="serviceType">The <see cref="Type"/> of the service.</param>
         /// <param name="implementationType">The <see cref="Type"/> implementing the service.</param>
         /// <param name="lifecycle">The <see cref="LifecycleKind"/> of the service.</param>
-        public ServiceDescriptor(Type serviceType, Type implementationType, LifecycleKind lifecycle)
+        public ServiceDescriptor([NotNull] Type serviceType, 
+                                 [NotNull] Type implementationType, 
+                                 LifecycleKind lifecycle)
             : this(serviceType, lifecycle)
         {
             ImplementationType = implementationType;
@@ -25,7 +27,8 @@ namespace Microsoft.Framework.DependencyInjection
         /// </summary>
         /// <param name="serviceType">The <see cref="Type"/> of the service.</param>
         /// <param name="instance">The instance implementing the service.</param>
-        public ServiceDescriptor(Type serviceType, object instance)
+        public ServiceDescriptor([NotNull] Type serviceType,
+                                 [NotNull] object instance)
             : this(serviceType, LifecycleKind.Singleton)
         {
             ImplementationInstance = instance;
@@ -37,7 +40,9 @@ namespace Microsoft.Framework.DependencyInjection
         /// <param name="serviceType">The <see cref="Type"/> of the service.</param>
         /// <param name="factory">A factory used for creating service instances.</param>
         /// <param name="lifecycle">The <see cref="LifecycleKind"/> of the service.</param>
-        public ServiceDescriptor(Type serviceType, Func<IServiceProvider, object> factory, LifecycleKind lifecycle)
+        public ServiceDescriptor([NotNull] Type serviceType,
+                                 [NotNull] Func<IServiceProvider, object> factory, 
+                                 LifecycleKind lifecycle)
             : this(serviceType, lifecycle)
         {
             ImplementationFactory = factory;

--- a/test/Microsoft.Framework.DependencyInjection.Tests/ServiceCollectionExtensionTest.cs
+++ b/test/Microsoft.Framework.DependencyInjection.Tests/ServiceCollectionExtensionTest.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Framework.DependencyInjection.Tests.Fakes;
+using Xunit;
+
+namespace Microsoft.Framework.DependencyInjection
+{
+    public class ServiceCollectionExtensionTest
+    {
+        private static readonly Func<IServiceProvider, object> _factory = _ => new object();
+        private static readonly FakeService _instance = new FakeService();
+
+        public static TheoryData AddImplementationTypeData
+        {
+            get
+            {
+                var serviceType = typeof(IFakeService);
+                var implementationType = typeof(FakeService);
+                return new TheoryData<Action<IServiceCollection>, Type, Type, LifecycleKind>
+                {
+                    { collection => collection.AddTransient(serviceType, implementationType), serviceType, implementationType, LifecycleKind.Transient },
+                    { collection => collection.AddTransient<IFakeService, FakeService>(), serviceType, implementationType, LifecycleKind.Transient },
+                    { collection => collection.AddTransient<IFakeService>(), serviceType, serviceType, LifecycleKind.Transient },
+                    { collection => collection.AddTransient(implementationType), implementationType, implementationType, LifecycleKind.Transient },
+
+                    { collection => collection.AddScoped(serviceType, implementationType), serviceType, implementationType, LifecycleKind.Scoped },
+                    { collection => collection.AddScoped<IFakeService, FakeService>(), serviceType, implementationType, LifecycleKind.Scoped },
+                    { collection => collection.AddScoped<IFakeService>(), serviceType, serviceType, LifecycleKind.Scoped },
+                    { collection => collection.AddScoped(implementationType), implementationType, implementationType, LifecycleKind.Scoped },
+
+                    { collection => collection.AddSingleton(serviceType, implementationType), serviceType, implementationType, LifecycleKind.Singleton },
+                    { collection => collection.AddSingleton<IFakeService, FakeService>(), serviceType, implementationType, LifecycleKind.Singleton },
+                    { collection => collection.AddSingleton<IFakeService>(), serviceType, serviceType, LifecycleKind.Singleton },
+                    { collection => collection.AddSingleton(implementationType), implementationType, implementationType, LifecycleKind.Singleton },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(AddImplementationTypeData))]
+        public void AddWithTypeAddsServiceWithRightLifecyle(Action<IServiceCollection> addTypeAction,
+                                                            Type expectedServiceType,
+                                                            Type expectedImplementationType,
+                                                            LifecycleKind lifeCycle)
+        {
+            // Arrange
+            var collection = new ServiceCollection();
+
+            // Act
+            addTypeAction(collection);
+
+            // Assert
+            var descriptor = Assert.Single(collection);
+            Assert.Equal(expectedServiceType, descriptor.ServiceType);
+            Assert.Equal(expectedImplementationType, descriptor.ImplementationType);
+            Assert.Equal(lifeCycle, descriptor.Lifecycle);
+        }
+
+        public static TheoryData AddImplementationFactoryData
+        {
+            get
+            {
+                var serviceType = typeof(IFakeService);
+
+                return new TheoryData<Action<IServiceCollection>, LifecycleKind>
+                {
+                    { collection => collection.AddTransient<IFakeService>(_factory), LifecycleKind.Transient },
+                    { collection => collection.AddTransient(serviceType, _factory), LifecycleKind.Transient },
+
+                    { collection => collection.AddScoped<IFakeService>(_factory), LifecycleKind.Scoped },
+                    { collection => collection.AddScoped(serviceType, _factory), LifecycleKind.Scoped },
+
+                    { collection => collection.AddSingleton<IFakeService>(_factory), LifecycleKind.Singleton },
+                    { collection => collection.AddSingleton(serviceType, _factory), LifecycleKind.Singleton },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(AddImplementationFactoryData))]
+        public void AddWithFactoryAddsServiceWithRightLifecyle(Action<IServiceCollection> addAction,
+                                                               LifecycleKind lifeCycle)
+        {
+            // Arrange
+            var collection = new ServiceCollection();
+
+            // Act
+            addAction(collection);
+
+            // Assert
+            var descriptor = Assert.Single(collection);
+            Assert.Equal(typeof(IFakeService), descriptor.ServiceType);
+            Assert.Same(_factory, descriptor.ImplementationFactory);
+            Assert.Equal(lifeCycle, descriptor.Lifecycle);
+        }
+
+        public static TheoryData AddInstanceData
+        {
+            get
+            {
+                return new TheoryData<Action<IServiceCollection>>
+                {
+                    { collection => collection.AddInstance<IFakeService>(_instance) },
+                    { collection => collection.AddInstance(typeof(IFakeService), _instance) },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(AddInstanceData))]
+        public void AddInstance_AddsWithSingletonLifecycle(Action<IServiceCollection> addAction)
+        {
+            // Arrange
+            var collection = new ServiceCollection();
+
+            // Act
+            addAction(collection);
+
+            // Assert
+            var descriptor = Assert.Single(collection);
+            Assert.Equal(typeof(IFakeService), descriptor.ServiceType);
+            Assert.Same(_instance, descriptor.ImplementationInstance);
+            Assert.Equal(LifecycleKind.Singleton, descriptor.Lifecycle);
+        }
+    }
+}


### PR DESCRIPTION
- Remove use of IConfiguration from ServiceCollection
- Removing the Add\* methods from IServiceCollection that don't accept an
  IServiceDescriptor

Fixes #116 #117
