### PR TITLE
For all ServiceDescriber and ServiceCollectionExtension methods that use

### DIFF
--- a/src/Microsoft.Framework.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Framework.DependencyInjection/ServiceCollectionExtensions.cs
@@ -7,15 +7,15 @@ namespace Microsoft.Framework.DependencyInjection
 {
     public static class ServiceCollectionExtensions
     {
-        public static IServiceCollection AddTransient([NotNull] this IServiceCollection collection, 
-                                                      [NotNull] Type service, 
+        public static IServiceCollection AddTransient([NotNull] this IServiceCollection collection,
+                                                      [NotNull] Type service,
                                                       [NotNull] Type implementationType)
         {
             return Add(collection, service, implementationType, LifecycleKind.Transient);
         }
 
         public static IServiceCollection AddTransient([NotNull] this IServiceCollection collection,
-                                                      [NotNull] Type service, 
+                                                      [NotNull] Type service,
                                                       [NotNull] Func<IServiceProvider, object> implementationFactory)
         {
             return Add(collection, service, implementationFactory, LifecycleKind.Transient);
@@ -58,6 +58,7 @@ namespace Microsoft.Framework.DependencyInjection
         }
 
         public static IServiceCollection AddTransient<TService, TImplementation>([NotNull] this IServiceCollection services)
+            where TImplementation : TService
         {
             return services.AddTransient(typeof(TService), typeof(TImplementation));
         }
@@ -74,12 +75,14 @@ namespace Microsoft.Framework.DependencyInjection
         }
 
         public static IServiceCollection AddTransient<TService>([NotNull] this IServiceCollection services,
-                                                                [NotNull] Func<IServiceProvider, object> implementationFactory)
+                                                                [NotNull] Func<IServiceProvider, TService> implementationFactory)
+            where TService : class
         {
             return services.AddTransient(typeof(TService), implementationFactory);
         }
 
         public static IServiceCollection AddScoped<TService, TImplementation>([NotNull] this IServiceCollection services)
+            where TImplementation : TService
         {
             return services.AddScoped(typeof(TService), typeof(TImplementation));
         }
@@ -91,7 +94,8 @@ namespace Microsoft.Framework.DependencyInjection
         }
 
         public static IServiceCollection AddScoped<TService>([NotNull] this IServiceCollection services,
-                                                             [NotNull] Func<IServiceProvider, object> implementationFactory)
+                                                             [NotNull] Func<IServiceProvider, TService> implementationFactory)
+            where TService : class
         {
             return services.AddScoped(typeof(TService), implementationFactory);
         }
@@ -106,7 +110,7 @@ namespace Microsoft.Framework.DependencyInjection
             return services.AddSingleton(typeof(TService), typeof(TImplementation));
         }
 
-        public static IServiceCollection AddSingleton([NotNull] this IServiceCollection services, 
+        public static IServiceCollection AddSingleton([NotNull] this IServiceCollection services,
                                                       [NotNull] Type serviceType)
         {
             return services.AddSingleton(serviceType, serviceType);
@@ -118,12 +122,13 @@ namespace Microsoft.Framework.DependencyInjection
         }
 
         public static IServiceCollection AddSingleton<TService>([NotNull] this IServiceCollection services,
-                                                                [NotNull] Func<IServiceProvider, object> implementationFactory)
+                                                                [NotNull] Func<IServiceProvider, TService> implementationFactory)
+            where TService : class
         {
             return services.AddSingleton(typeof(TService), implementationFactory);
         }
 
-        public static IServiceCollection AddInstance<TService>([NotNull] this IServiceCollection services, 
+        public static IServiceCollection AddInstance<TService>([NotNull] this IServiceCollection services,
                                                                [NotNull] TService implementationInstance)
             where TService : class
         {

--- a/src/Microsoft.Framework.DependencyInjection/ServiceDescriber.cs
+++ b/src/Microsoft.Framework.DependencyInjection/ServiceDescriber.cs
@@ -15,32 +15,36 @@ namespace Microsoft.Framework.DependencyInjection
         {
         }
 
-        public ServiceDescriber(IConfiguration configuration)
+        public ServiceDescriber([NotNull] IConfiguration configuration)
         {
             _configuration = configuration;
         }
 
         public ServiceDescriptor Transient<TService, TImplementation>()
+            where TImplementation : TService
         {
             return Describe<TService, TImplementation>(LifecycleKind.Transient);
         }
 
-        public ServiceDescriptor Transient(Type service, Type implementationType)
+        public ServiceDescriptor Transient([NotNull] Type service, [NotNull] Type implementationType)
         {
             return Describe(service, implementationType, LifecycleKind.Transient);
         }
 
-        public ServiceDescriptor Transient<TService>(Func<IServiceProvider, object> implementationFactory)
+        public ServiceDescriptor Transient<TService>([NotNull] Func<IServiceProvider, TService> implementationFactory)
+            where TService : class
         {
             return Describe(typeof(TService), implementationFactory, LifecycleKind.Transient);
         }
 
-        public ServiceDescriptor Transient(Type service, Func<IServiceProvider, object> implementationFactory)
+        public ServiceDescriptor Transient([NotNull] Type service,
+                                           [NotNull] Func<IServiceProvider, object> implementationFactory)
         {
             return Describe(service, implementationFactory, LifecycleKind.Transient);
         }
 
         public ServiceDescriptor Scoped<TService, TImplementation>()
+            where TImplementation : TService
         {
             return Describe<TService, TImplementation>(LifecycleKind.Scoped);
         }
@@ -50,42 +54,48 @@ namespace Microsoft.Framework.DependencyInjection
             return Describe(service, implementationType, LifecycleKind.Scoped);
         }
 
-        public ServiceDescriptor Scoped<TService>(Func<IServiceProvider, object> implementationFactory)
+        public ServiceDescriptor Scoped<TService>([NotNull] Func<IServiceProvider, TService> implementationFactory)
+            where TService : class
         {
             return Describe(typeof(TService), implementationFactory, LifecycleKind.Scoped);
         }
 
-        public ServiceDescriptor Scoped(Type service, Func<IServiceProvider, object> implementationFactory)
+        public ServiceDescriptor Scoped([NotNull] Type service,
+                                        [NotNull] Func<IServiceProvider, object> implementationFactory)
         {
             return Describe(service, implementationFactory, LifecycleKind.Scoped);
         }
 
         public ServiceDescriptor Singleton<TService, TImplementation>()
+            where TImplementation : TService
         {
             return Describe<TService, TImplementation>(LifecycleKind.Singleton);
         }
 
-        public ServiceDescriptor Singleton(Type service, Type implementationType)
+        public ServiceDescriptor Singleton([NotNull] Type service, [NotNull] Type implementationType)
         {
             return Describe(service, implementationType, LifecycleKind.Singleton);
         }
 
-        public ServiceDescriptor Singleton<TService>(Func<IServiceProvider, object> implementationFactory)
+        public ServiceDescriptor Singleton<TService>([NotNull] Func<IServiceProvider, TService> implementationFactory)
+            where TService : class
         {
             return Describe(typeof(TService), implementationFactory, LifecycleKind.Singleton);
         }
 
-        public ServiceDescriptor Singleton(Type serviceType, Func<IServiceProvider, object> implementationFactory)
+        public ServiceDescriptor Singleton([NotNull] Type serviceType,
+                                           [NotNull] Func<IServiceProvider, object> implementationFactory)
         {
             return Describe(serviceType, implementationFactory, LifecycleKind.Singleton);
         }
 
-        public ServiceDescriptor Instance<TService>(object implementationInstance)
+        public ServiceDescriptor Instance<TService>([NotNull] TService implementationInstance)
         {
             return Instance(typeof(TService), implementationInstance);
         }
 
-        public ServiceDescriptor Instance(Type serviceType, object implementationInstance)
+        public ServiceDescriptor Instance([NotNull] Type serviceType,
+                                          [NotNull] object implementationInstance)
         {
             var implementationType = GetRemappedImplementationType(serviceType);
             if (implementationType != null)

--- a/test/Microsoft.Framework.DependencyInjection.Tests/ServiceCollectionExtensionTest.cs
+++ b/test/Microsoft.Framework.DependencyInjection.Tests/ServiceCollectionExtensionTest.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Framework.DependencyInjection
 {
     public class ServiceCollectionExtensionTest
     {
-        private static readonly Func<IServiceProvider, object> _factory = _ => new object();
+        private static readonly Func<IServiceProvider, IFakeService> _factory = _ => new FakeService();
         private static readonly FakeService _instance = new FakeService();
 
         public static TheoryData AddImplementationTypeData


### PR DESCRIPTION
generic type parameters, add generic type constraints

Fixes #135
