### PR TITLE
Remove portable target

### DIFF
--- a/src/Microsoft.Framework.DependencyInjection.Interfaces/project.json
+++ b/src/Microsoft.Framework.DependencyInjection.Interfaces/project.json
@@ -13,12 +13,6 @@
             "dependencies": {
                 "Microsoft.Framework.Runtime.Interfaces": "1.0.0-*"
             }
-        },
-        ".NETPortable,Version=v4.6,Profile=Profile151": {
-            "frameworkAssemblies": {
-                "System.Runtime": "",
-                "System.ComponentModel":  ""
-            }
         }
     }
 }

--- a/src/Microsoft.Framework.DependencyInjection/project.json
+++ b/src/Microsoft.Framework.DependencyInjection/project.json
@@ -15,15 +15,6 @@
                 "System.Threading": "4.0.10-beta-*",
                 "System.Threading.Tasks": "4.0.10-beta-*"
             }
-        },
-        ".NETPortable,Version=v4.6,Profile=Profile151": {
-            "frameworkAssemblies": {
-                "System.Collections.Concurrent": "",
-                "System.ComponentModel": "",
-                "System.Linq.Expressions": "",
-                "System.Threading": "",
-                "System.Threading.Tasks": ""
-            }
         }
     }
 }


### PR DESCRIPTION
Given the removal of ANIs, this isn't needed anymore