### PR TITLE
Moved ServiceProviderExtensions from namespace Microsoft.Framework.DependencyInjection to `System.

### DIFF
--- a/src/Microsoft.Framework.DependencyInjection.Interfaces/ServiceProviderExtensions.cs
+++ b/src/Microsoft.Framework.DependencyInjection.Interfaces/ServiceProviderExtensions.cs
@@ -6,8 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Framework.DependencyInjection.Interfaces;
 using Microsoft.Framework.Internal;
+using Microsoft.Framework.DependencyInjection;
 
-namespace Microsoft.Framework.DependencyInjection
+namespace System
 {
     public static class ServiceProviderExtensions
     {
@@ -35,7 +36,7 @@ namespace Microsoft.Framework.DependencyInjection
 
             if (service == null)
             {
-                throw new InvalidOperationException(Resources.FormatNoServiceRegistered(serviceType));
+                throw new InvalidOperationException(Microsoft.Framework.DependencyInjection.Interfaces.Resources.FormatNoServiceRegistered(serviceType));
             }
 
             return service;
@@ -66,7 +67,7 @@ namespace Microsoft.Framework.DependencyInjection
 
             if (!providers.Any())
             {
-                throw new InvalidOperationException(Resources.FormatNoServiceRegistered(typeof(T)));
+                throw new InvalidOperationException(Microsoft.Framework.DependencyInjection.Interfaces.Resources.FormatNoServiceRegistered(typeof(T)));
             }
 
             return providers;

--- a/test/Microsoft.Framework.DependencyInjection.Tests/Fakes/TestServices.cs
+++ b/test/Microsoft.Framework.DependencyInjection.Tests/Fakes/TestServices.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.Framework.DependencyInjection.Tests.Fakes
 {
     public static class TestServices


### PR DESCRIPTION
This is so that `Microsoft.Framework.DependencyInjection` doesn't have to be added as a using every time you to get a strongly typed value from IServiceProvider.

It's entirely possible there is a very good reason that this isn't in the `System` namespace already, but this is one of the small pain points I currently encounter when working with Aspnet 5 day to day.