### PR TITLE
Replace portable target with netcore451

### DIFF
--- a/src/Microsoft.Framework.DependencyInjection.Interfaces/project.json
+++ b/src/Microsoft.Framework.DependencyInjection.Interfaces/project.json
@@ -19,7 +19,7 @@
                 "System.Resources.ResourceManager": "4.0.0-beta-*"
             }
         },
-        ".NETPortable,Version=v4.6,Profile=Profile151": {
+        "netcore451": {
             "frameworkAssemblies": {
                 "System.ComponentModel": "",
                 "System.Diagnostics.Debug": "",

--- a/src/Microsoft.Framework.DependencyInjection/project.json
+++ b/src/Microsoft.Framework.DependencyInjection/project.json
@@ -16,7 +16,7 @@
                 "System.Threading.Tasks": "4.0.10-beta-*"
             }
         },
-        ".NETPortable,Version=v4.6,Profile=Profile151": {
+        "netcore451": {
             "frameworkAssemblies": {
                 "System.Collections": "",
                 "System.Collections.Concurrent": "",


### PR DESCRIPTION
(This will collapse into `core50` when DNX and the Tools for Windows 10 support it.)