### PR TITLE
Using 'nameof' operator instead of magic strings

### DIFF
--- a/test/Microsoft.Framework.DependencyInjection.Tests/Utils/MultiServiceHelpers.cs
+++ b/test/Microsoft.Framework.DependencyInjection.Tests/Utils/MultiServiceHelpers.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Framework.DependencyInjection.Tests
         {
             if (collection == null)
             {
-                throw new ArgumentNullException("collection");
+                throw new ArgumentNullException(nameof(collection));
             }
 
             IList castedCollection = CreateEmptyList(castItemsTo);


### PR DESCRIPTION
Using the "nameof" operator instead of magic string will help us if the variable change in the future for whatever the reason