### PR TITLE
Don't manipulate the scope while resolving instances

### DIFF
--- a/src/Microsoft.Framework.DependencyInjection.Ninject/ServiceProviderNinjectModule.cs
+++ b/src/Microsoft.Framework.DependencyInjection.Ninject/ServiceProviderNinjectModule.cs
@@ -62,9 +62,6 @@ namespace Microsoft.Framework.DependencyInjection.Ninject
                 var resolver = context.Kernel.Get<IResolutionRoot>();
                 var inheritedParams = context.Parameters.Where(p => p.ShouldInherit);
 
-                var scopeParam = new ScopeParameter();
-                inheritedParams = inheritedParams.AddOrReplaceScopeParameter(scopeParam);
-
                 return new NinjectServiceProvider(resolver, inheritedParams.ToArray());
             }).InRequestScope();
 


### PR DESCRIPTION
I have been chasing down a NRE when using `[FromBody]` in MVC to these two lines from the Ninject DI bridge.

The problem as far as I could identify starts in the [MvcRouteHandler](https://github.com/aspnet/Mvc/blob/dev/src/Microsoft.AspNet.Mvc.Core/MvcRouteHandler.cs#L96) where the request's `IServiceProvider` is used to get an `IScopedInstance<ActionContext>`. After that, an `IActionInvokerFactory` is constructed and down the dependency chain, an `IServiceProvider` is injected into one of the `OptionDescriptorBasedProvider`. The latter `IServiceProvider` is not the one used in MvcRouteHandler, but instead a new `NinjectServiceProvider` is created, which doesn't know about the initialized `IScopedInstance<ActionContext>`. So it creates a new, uninitialized one and injects that into `BodyModelBinder` where it throws a NRE.

The reason is that while creating an `IServiceProvider`, the Ninject bridge also changes the scope parameter and so the provider for the current request isn't found anymore when creating child objects.