### PR TITLE
Add a TryAddMultiRegistration variant

### DIFF
--- a/src/Microsoft.Framework.DependencyInjection.Abstractions/Properties/Resources.Designer.cs
+++ b/src/Microsoft.Framework.DependencyInjection.Abstractions/Properties/Resources.Designer.cs
@@ -90,6 +90,22 @@ namespace Microsoft.Framework.DependencyInjection.Abstractions
             return string.Format(CultureInfo.CurrentCulture, GetString("NoServiceRegistered"), p0);
         }
 
+        /// <summary>
+        /// The {0} must have the {1} property set to a non-null value.
+        /// </summary>
+        internal static string TryAddEnumerable_ImplementationTypeMustBeSet
+        {
+            get { return GetString("TryAddEnumerable_ImplementationTypeMustBeSet"); }
+        }
+
+        /// <summary>
+        /// The {0} must have the {1} property set to a non-null value.
+        /// </summary>
+        internal static string FormatTryAddEnumerable_ImplementationTypeMustBeSet(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TryAddEnumerable_ImplementationTypeMustBeSet"), p0, p1);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.Framework.DependencyInjection.Abstractions/Resources.resx
+++ b/src/Microsoft.Framework.DependencyInjection.Abstractions/Resources.resx
@@ -137,4 +137,8 @@
     <value>No service for type '{0}' has been registered.</value>
     <comment>{0} = service type</comment>
   </data>
+  <data name="TryAddEnumerable_ImplementationTypeMustBeSet" xml:space="preserve">
+    <value>The {0} must have the {1} property set to a non-null value.</value>
+    <comment>{0} = ServiceDescriptor, {1} = ImplementationType</comment>
+  </data>
 </root>

--- a/test/Microsoft.Framework.DependencyInjection.Tests/project.json
+++ b/test/Microsoft.Framework.DependencyInjection.Tests/project.json
@@ -1,6 +1,7 @@
 {
     "version": "0.1-alpha-*",
     "dependencies": {
+        "Microsoft.AspNet.Testing": "1.0.0-*",
         "Microsoft.Framework.DependencyInjection": "1.0.0-*",
         "Microsoft.Framework.NotNullAttribute.Sources": { "version": "1.0.0-*", "type": "build" },
         "xunit.runner.aspnet": "2.0.0-aspnet-*"


### PR DESCRIPTION
We're using something like this in MVC to avoid repeatedly adding our
options setups when called twice. This makes AddMvcCore() idempotent,
which is pretty important to make our more complex configuration scenarios
more straightforward.