### PR TITLE
Adding additional unit tests for covering TypeActivator instantiating

### DIFF
--- a/test/Microsoft.Framework.DependencyInjection.Tests/ActivatorUtilitiesTests.cs
+++ b/test/Microsoft.Framework.DependencyInjection.Tests/ActivatorUtilitiesTests.cs
@@ -102,14 +102,19 @@ namespace Microsoft.Framework.DependencyInjection.Abstractions.Tests
             Assert.NotNull(instance);
         }
 
+        public static IEnumerable<object[]> TypesWithNonPublicConstructorData =>
+            CreateInstanceFuncs.Zip(
+                    new[] { typeof(ClassWithPrivateCtor), typeof(ClassWithInternalConstructor), typeof(ClassWithProtectedConstructor) },
+                    (a, b) => new object[] { a[0], b });
+
         [Theory]
-        [MemberData(nameof(CreateInstanceFuncs))]
-        public void TypeActivatorRequiresPublicConstructor(CreateInstanceFunc createFunc)
+        [MemberData(nameof(TypesWithNonPublicConstructorData))]
+        public void TypeActivatorRequiresPublicConstructor(CreateInstanceFunc createFunc, Type type)
         {
             var ex = Assert.Throws<InvalidOperationException>(() =>
-                CreateInstance<ClassWithPrivateCtor>(createFunc, provider: null));
+                createFunc(provider: null, type: type, args: new object[0]));
 
-            Assert.Equal(Resources.FormatNoConstructorMatch(typeof(ClassWithPrivateCtor)), ex.Message);
+            Assert.Equal(Resources.FormatNoConstructorMatch(type), ex.Message);
         }
 
         [Theory]

--- a/test/Microsoft.Framework.DependencyInjection.Tests/Fakes/ClassWithInternalConstructor.cs
+++ b/test/Microsoft.Framework.DependencyInjection.Tests/Fakes/ClassWithInternalConstructor.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Framework.DependencyInjection
+{
+    public class ClassWithInternalConstructor
+    {
+        internal ClassWithInternalConstructor()
+        {
+        }
+    }
+}

--- a/test/Microsoft.Framework.DependencyInjection.Tests/Fakes/ClassWithProtectedConstructor.cs
+++ b/test/Microsoft.Framework.DependencyInjection.Tests/Fakes/ClassWithProtectedConstructor.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Framework.DependencyInjection
+{
+    public class ClassWithProtectedConstructor
+    {
+        internal ClassWithProtectedConstructor()
+        {
+        }
+    }
+}


### PR DESCRIPTION
types with non-public constructors.

Fixes https://github.com/aspnet/DependencyInjection/issues/182