### PR TITLE
Use earliest compatible dependencies

### DIFF
--- a/src/Microsoft.Framework.DependencyInjection.Abstractions/project.json
+++ b/src/Microsoft.Framework.DependencyInjection.Abstractions/project.json
@@ -17,13 +17,14 @@
         "dnx451": { },
         "dotnet": {
             "dependencies": {
-                "System.ComponentModel": "4.0.1-beta-*",
-                "System.Diagnostics.Debug": "4.0.11-beta-*",
-                "System.Globalization": "4.0.11-beta-*",
-                "System.Linq": "4.0.1-beta-*",
-                "System.Linq.Expressions": "4.0.11-beta-*",
-                "System.Reflection": "4.0.11-beta-*",
-                "System.Resources.ResourceManager": "4.0.1-beta-*"
+                "System.ComponentModel": "4.0.0",
+                "System.Diagnostics.Debug": "4.0.0",
+                "System.Globalization": "4.0.0",
+                "System.Linq": "4.0.0",
+                "System.Linq.Expressions": "4.0.0",
+                "System.Reflection": "4.0.0",
+                "System.Resources.ResourceManager": "4.0.0",
+                "System.Runtime": "4.0.0"
             }
         }
     }

--- a/src/Microsoft.Framework.DependencyInjection/project.json
+++ b/src/Microsoft.Framework.DependencyInjection/project.json
@@ -17,10 +17,19 @@
         "dnx451": { },
         "dotnet": {
             "dependencies": {
-                "System.Collections": "4.0.11-beta-*",
-                "System.Collections.Concurrent": "4.0.11-beta-*",
-                "System.Threading": "4.0.11-beta-*",
-                "System.Threading.Tasks": "4.0.11-beta-*"
+                "System.Collections": "4.0.0",
+                "System.Collections.Concurrent": "4.0.0",
+                "System.ComponentModel": "4.0.0",
+                "System.Diagnostics.Debug": "4.0.0",
+                "System.Globalization": "4.0.0",
+                "System.Linq": "4.0.0",
+                "System.Linq.Expressions": "4.0.0",
+                "System.Reflection": "4.0.0",
+                "System.Resources.ResourceManager": "4.0.0",
+                "System.Runtime": "4.0.0",
+                "System.Runtime.Extensions": "4.0.0",
+                "System.Threading": "4.0.0",
+                "System.Threading.Tasks": "4.0.0"
             }
         }
     }


### PR DESCRIPTION
Enables our packages to work on more platforms with more libraries
