### PR TITLE
[Design]: Changes to improve performance

### DIFF
--- a/src/Microsoft.Framework.DependencyInjection/Internal/ConcurrentDictionaryExtensions.cs
+++ b/src/Microsoft.Framework.DependencyInjection/Internal/ConcurrentDictionaryExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 
 namespace System.Collections.Concurrent
 {
@@ -8,20 +9,9 @@ namespace System.Collections.Concurrent
         // This lets us pass a state parameter allocation free GetOrAdd
         internal static TValue GetOrAdd<TKey, TValue, TArg>(this ConcurrentDictionary<TKey, TValue> dictionary, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg arg)
         {
-            if (dictionary == null)
-            {
-                throw new ArgumentNullException(nameof(dictionary));
-            }
-
-            if (key == null)
-            {
-                throw new ArgumentNullException(nameof(key));
-            }
-
-            if (valueFactory == null)
-            {
-                throw new ArgumentNullException(nameof(valueFactory));
-            }
+            Debug.Assert(dictionary != null);
+            Debug.Assert(key != null);
+            Debug.Assert(valueFactory != null);
 
             while (true)
             {

--- a/src/Microsoft.Framework.DependencyInjection/Internal/ConcurrentDictionaryExtensions.cs
+++ b/src/Microsoft.Framework.DependencyInjection/Internal/ConcurrentDictionaryExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace System.Collections.Concurrent
+{
+    internal static class ConcurrentDictionaryExtensions
+    {
+        // From https://github.com/dotnet/corefx/issues/394#issuecomment-69494764
+        // This lets us pass a state parameter allocation free GetOrAdd
+        internal static TValue GetOrAdd<TKey, TValue, TArg>(this ConcurrentDictionary<TKey, TValue> dictionary, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg arg)
+        {
+            if (dictionary == null)
+            {
+                throw new ArgumentNullException(nameof(dictionary));
+            }
+
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            if (valueFactory == null)
+            {
+                throw new ArgumentNullException(nameof(valueFactory));
+            }
+
+            while (true)
+            {
+                TValue value;
+                if (dictionary.TryGetValue(key, out value))
+                {
+                    return value;
+                }
+
+                value = valueFactory(key, arg);
+                if (dictionary.TryAdd(key, value))
+                {
+                    return value;
+                }
+            }
+        }
+
+    }
+}

--- a/src/Microsoft.Framework.DependencyInjection/ServiceProvider.cs
+++ b/src/Microsoft.Framework.DependencyInjection/ServiceProvider.cs
@@ -153,10 +153,12 @@ namespace Microsoft.Framework.DependencyInjection
                     _transientDisposables.Clear();
                 }
 
-                // Nuke the other service types
-                foreach (var item in _resolvedServices.Values)
+                // PERF: We've enumerating the dictionary so that we don't allocate to enumerate.
+                // .Values allocates a KeyCollection on the heap, enumerating the dictionary allocates
+                // a struct enumerator
+                foreach (var entry in _resolvedServices)
                 {
-                    (item as IDisposable)?.Dispose();
+                    (entry.Value as IDisposable)?.Dispose();
                 }
 
                 _resolvedServices.Clear();

--- a/test/Microsoft.Framework.DependencyInjection.Tests/ScopingContainerTestBase.cs
+++ b/test/Microsoft.Framework.DependencyInjection.Tests/ScopingContainerTestBase.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Framework.DependencyInjection.Tests
         {
             var container = CreateContainer();
             FakeService disposableService;
--           FakeService transient1;
+            FakeService transient1;
             FakeService transient2;
 
             var scopeFactory = container.GetService<IServiceScopeFactory>();

--- a/test/Microsoft.Framework.DependencyInjection.Tests/ScopingContainerTestBase.cs
+++ b/test/Microsoft.Framework.DependencyInjection.Tests/ScopingContainerTestBase.cs
@@ -76,16 +76,24 @@ namespace Microsoft.Framework.DependencyInjection.Tests
         {
             var container = CreateContainer();
             FakeService disposableService;
+-           FakeService transient1;
+            FakeService transient2;
 
             var scopeFactory = container.GetService<IServiceScopeFactory>();
             using (var scope = scopeFactory.CreateScope())
             {
                 disposableService = (FakeService)scope.ServiceProvider.GetService<IFakeScopedService>();
+                transient1 = (FakeService)scope.ServiceProvider.GetService<IFakeService>();
+                transient2 = (FakeService)scope.ServiceProvider.GetService<IFakeService>();
 
                 Assert.False(disposableService.Disposed);
+                Assert.False(transient1.Disposed);
+                Assert.False(transient2.Disposed);
             }
 
             Assert.True(disposableService.Disposed);
+            Assert.True(transient1.Disposed);
+            Assert.True(transient2.Disposed);
         }
 
         [Fact]

--- a/test/Microsoft.Framework.DependencyInjection.Tests/ScopingContainerTestBase.cs
+++ b/test/Microsoft.Framework.DependencyInjection.Tests/ScopingContainerTestBase.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Framework.DependencyInjection.Tests
             FakeService disposableService;
             FakeService transient1;
             FakeService transient2;
+            FakeService singleton;
 
             var scopeFactory = container.GetService<IServiceScopeFactory>();
             using (var scope = scopeFactory.CreateScope())
@@ -85,15 +86,25 @@ namespace Microsoft.Framework.DependencyInjection.Tests
                 disposableService = (FakeService)scope.ServiceProvider.GetService<IFakeScopedService>();
                 transient1 = (FakeService)scope.ServiceProvider.GetService<IFakeService>();
                 transient2 = (FakeService)scope.ServiceProvider.GetService<IFakeService>();
+                singleton = (FakeService)scope.ServiceProvider.GetService<IFakeSingletonService>();
 
                 Assert.False(disposableService.Disposed);
                 Assert.False(transient1.Disposed);
                 Assert.False(transient2.Disposed);
+                Assert.False(singleton.Disposed);
             }
 
             Assert.True(disposableService.Disposed);
             Assert.True(transient1.Disposed);
             Assert.True(transient2.Disposed);
+            Assert.False(singleton.Disposed);
+
+            var disposableContainer = container as IDisposable;
+            if (disposableContainer != null)
+            {
+                disposableContainer.Dispose();
+                Assert.True(singleton.Disposed);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
- Track disposables in a list with lock instead of a concurrent bag
- Allocate a single _createServiceAccessor instead of one per instance
- Removed syncObject and just locked the _resolvedServices

Measurements on the way...

/cc @rynowak @halter73 @pranavkm @lodejard @benaadams 
