### PR TITLE
Add generic TryAdd with implementation factory

### DIFF
--- a/src/Microsoft.Extensions.DependencyInjection.Abstractions/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.DependencyInjection.Abstractions/Extensions/ServiceCollectionExtensions.cs
@@ -203,6 +203,14 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
             TryAddTransient(collection, typeof(TService), typeof(TImplementation));
         }
 
+        public static void TryAddTransient<TService>(
+            this IServiceCollection services,
+            Func<IServiceProvider, TService> implementationFactory)
+            where TService : class
+        {
+            services.TryAdd(ServiceDescriptor.Transient(implementationFactory));
+        }
+
         public static void TryAddScoped(
             this IServiceCollection collection,
             Type service)
@@ -292,6 +300,14 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
             TryAddScoped(collection, typeof(TService), typeof(TImplementation));
         }
 
+        public static void TryAddScoped<TService>(
+            this IServiceCollection services,
+            Func<IServiceProvider, TService> implementationFactory)
+            where TService : class
+        {
+            services.TryAdd(ServiceDescriptor.Scoped(implementationFactory));
+        }
+
         public static void TryAddSingleton(
             this IServiceCollection collection,
             Type service)
@@ -379,6 +395,14 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
             }
 
             TryAddSingleton(collection, typeof(TService), typeof(TImplementation));
+        }
+
+        public static void TryAddSingleton<TService>(
+            this IServiceCollection services,
+            Func<IServiceProvider, TService> implementationFactory)
+            where TService : class
+        {
+            services.TryAdd(ServiceDescriptor.Singleton(implementationFactory));
         }
 
         /// <summary>


### PR DESCRIPTION
Adds a generic `TryAdd` (transient/scoped/singleton) with a generic implementation factory as parameter.