### PR TITLE
Address #340

### DIFF
--- a/src/Microsoft.Extensions.DependencyInjection.Specification.Tests/Fakes/FakeDecoratingMultipleService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection.Specification.Tests/Fakes/FakeDecoratingMultipleService.cs
@@ -1,0 +1,15 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
+{
+    public class FakeDecoratingMultipleService : IFakeMultipleService
+    {
+        public FakeDecoratingMultipleService(IFakeMultipleService inner)
+        {
+            Inner = inner;
+        }
+
+        public IFakeMultipleService Inner { get; }
+    }
+}

--- a/src/Microsoft.Extensions.DependencyInjection/Properties/Resources.Designer.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/Properties/Resources.Designer.cs
@@ -11,19 +11,19 @@ namespace Microsoft.Extensions.DependencyInjection
             = new ResourceManager("Microsoft.Extensions.DependencyInjection.Resources", typeof(Resources).GetTypeInfo().Assembly);
 
         /// <summary>
-        /// Unable to activate type '{0}'. The following constructors are ambigious:
+        /// Unable to activate type '{0}'. The following constructors are ambiguous:
         /// </summary>
-        internal static string AmbigiousConstructorException
+        internal static string AmbiguousConstructorException
         {
-            get { return GetString("AmbigiousConstructorException"); }
+            get { return GetString("AmbiguousConstructorException"); }
         }
 
         /// <summary>
-        /// Unable to activate type '{0}'. The following constructors are ambigious:
+        /// Unable to activate type '{0}'. The following constructors are ambiguous:
         /// </summary>
-        internal static string FormatAmbigiousConstructorException(object p0)
+        internal static string FormatAmbiguousConstructorException(object p0)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("AmbigiousConstructorException"), p0);
+            return string.Format(CultureInfo.CurrentCulture, GetString("AmbiguousConstructorException"), p0);
         }
 
         /// <summary>
@@ -40,22 +40,6 @@ namespace Microsoft.Extensions.DependencyInjection
         internal static string FormatCannotResolveService(object p0, object p1)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("CannotResolveService"), p0, p1);
-        }
-
-        /// <summary>
-        /// A circular dependency was detected for the service of type '{0}'.
-        /// </summary>
-        internal static string CircularDependencyException
-        {
-            get { return GetString("CircularDependencyException"); }
-        }
-
-        /// <summary>
-        /// A circular dependency was detected for the service of type '{0}'.
-        /// </summary>
-        internal static string FormatCircularDependencyException(object p0)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("CircularDependencyException"), p0);
         }
 
         /// <summary>

--- a/src/Microsoft.Extensions.DependencyInjection/Resources.resx
+++ b/src/Microsoft.Extensions.DependencyInjection/Resources.resx
@@ -117,16 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AmbigiousConstructorException" xml:space="preserve">
-    <value>Unable to activate type '{0}'. The following constructors are ambigious:</value>
+  <data name="AmbiguousConstructorException" xml:space="preserve">
+    <value>Unable to activate type '{0}'. The following constructors are ambiguous:</value>
   </data>
   <data name="CannotResolveService" xml:space="preserve">
     <value>Unable to resolve service for type '{0}' while attempting to activate '{1}'.</value>
     <comment>{0} = service which cannot be resolved, {1} = service being activated</comment>
-  </data>
-  <data name="CircularDependencyException" xml:space="preserve">
-    <value>A circular dependency was detected for the service of type '{0}'.</value>
-    <comment>{0} = service type with circular dependency</comment>
   </data>
   <data name="UnableToActivateTypeException" xml:space="preserve">
     <value>No constructor for type '{0}' can be instantiated using services from the service container and default values.</value>

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/FactoryService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/FactoryService.cs
@@ -16,14 +16,13 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             _descriptor = descriptor;
         }
 
+        public IService Previous { get; set; }
+
         public IService Next { get; set; }
 
-        public ServiceLifetime Lifetime
-        {
-            get { return _descriptor.Lifetime; }
-        }
+        public ServiceLifetime Lifetime => _descriptor.Lifetime;
 
-        public IServiceCallSite CreateCallSite(ServiceProvider provider, ISet<Type> callSiteChain)
+        public IServiceCallSite CreateCallSite(ServiceProvider provider)
         {
             return this;
         }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/IService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/IService.cs
@@ -1,17 +1,16 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal interface IService
     {
+        IService Previous { get; set; }
+
         IService Next { get; set; }
 
         ServiceLifetime Lifetime { get; }
 
-        IServiceCallSite CreateCallSite(ServiceProvider provider, ISet<Type> callSiteChain);
+        IServiceCallSite CreateCallSite(ServiceProvider provider);
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/InstanceService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/InstanceService.cs
@@ -19,14 +19,13 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             _descriptor = descriptor;
         }
 
+        public IService Previous { get; set; }
+
         public IService Next { get; set; }
 
-        public ServiceLifetime Lifetime
-        {
-            get { return _descriptor.Lifetime; }
-        }
+        public ServiceLifetime Lifetime => _descriptor.Lifetime;
 
-        public IServiceCallSite CreateCallSite(ServiceProvider provider, ISet<Type> callSiteChain)
+        public IServiceCallSite CreateCallSite(ServiceProvider provider)
         {
             return this;
         }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/OpenIEnumerableService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/OpenIEnumerableService.cs
@@ -15,19 +15,20 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             _table = table;
         }
 
-        public ServiceLifetime Lifetime
-        {
-            get { return ServiceLifetime.Transient; }
-        }
+        public ServiceLifetime Lifetime => ServiceLifetime.Transient;
 
         public IService GetService(Type closedServiceType)
         {
             var itemType = closedServiceType.GetTypeInfo().GenericTypeArguments[0];
 
             ServiceEntry entry;
-            return _table.TryGetEntry(itemType, out entry) ?
-                new ClosedIEnumerableService(itemType, entry) :
-                null;
+
+            if (_table.TryGetEntry(itemType, out entry))
+            {
+                return new ClosedIEnumerableService(entry);
+            }
+
+            return null;
         }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ServiceEntry.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ServiceEntry.cs
@@ -1,27 +1,94 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal class ServiceEntry
     {
         private object _sync = new object();
 
-        public ServiceEntry(IService service)
+        public ServiceEntry(Type serviceType)
         {
-            First = service;
-            Last = service;
+            ServiceType = serviceType;
         }
 
+        public Type ServiceType { get; private set; }
+
         public IService First { get; private set; }
+
         public IService Last { get; private set; }
 
-        public void Add(IService service)
+        public void Link(IService service)
         {
+            if (service == null)
+            {
+                return;
+            }
+
             lock (_sync)
             {
-                Last.Next = service;
-                Last = service;
+                if (service.Next != null)
+                {
+                    service.Next.Previous = service;
+                }
+                else if (Last == null)
+                {
+                    Last = service;
+                }
+                else
+                {
+                    service.Previous = Last;
+                    Last.Next = service;
+                    Last = service;
+                }
+
+                if (service.Previous != null)
+                {
+                    service.Previous.Next = service;
+                }
+                else if (First == null)
+                {
+                    First = service;
+                }
+                else
+                {
+                    service.Next = First;
+                    First.Previous = service;
+                    First = service;
+                }
+            }
+        }
+
+        public void Unlink(IService service)
+        {
+            if (service == null)
+            {
+                return;
+            }
+
+            lock (_sync)
+            {
+                if (service == First)
+                {
+                    First = service.Next;
+                }
+
+                if (service == Last)
+                {
+                    Last = service.Previous;
+                }
+
+                if (service.Next != null)
+                {
+                    service.Next.Previous = service.Previous;
+                }
+
+                if (service.Previous != null)
+                {
+                    service.Previous.Next = service.Next;
+                }
             }
         }
     }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ServiceProviderService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ServiceProviderService.cs
@@ -9,14 +9,13 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal class ServiceProviderService : IService, IServiceCallSite
     {
+        public IService Previous { get; set; }
+
         public IService Next { get; set; }
 
-        public ServiceLifetime Lifetime
-        {
-            get { return ServiceLifetime.Scoped; }
-        }
+        public ServiceLifetime Lifetime => ServiceLifetime.Scoped;
 
-        public IServiceCallSite CreateCallSite(ServiceProvider provider, ISet<Type> callSiteChain)
+        public IServiceCallSite CreateCallSite(ServiceProvider provider)
         {
             return this;
         }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ServiceScopeService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ServiceScopeService.cs
@@ -11,14 +11,13 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal class ServiceScopeService : IService, IServiceCallSite
     {
+        public IService Previous { get; set; }
+
         public IService Next { get; set; }
 
-        public ServiceLifetime Lifetime
-        {
-            get { return ServiceLifetime.Scoped; }
-        }
+        public ServiceLifetime Lifetime => ServiceLifetime.Scoped;
 
-        public IServiceCallSite CreateCallSite(ServiceProvider provider, ISet<Type> callSiteChain)
+        public IServiceCallSite CreateCallSite(ServiceProvider provider)
         {
             return this;
         }

--- a/test/Microsoft.Extensions.DependencyInjection.Tests/CallSiteTests.cs
+++ b/test/Microsoft.Extensions.DependencyInjection.Tests/CallSiteTests.cs
@@ -83,8 +83,8 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         {
             var provider = new ServiceProvider(desciptors);
 
-            var callSite = provider.GetServiceCallSite(serviceType, new HashSet<Type>());
-            var collectionCallSite = provider.GetServiceCallSite(typeof(IEnumerable<>).MakeGenericType(serviceType), new HashSet<Type>());
+            var callSite = provider.GetServiceCallSite(serviceType);
+            var collectionCallSite = provider.GetServiceCallSite(typeof(IEnumerable<>).MakeGenericType(serviceType));
 
             var compiledCallSite = CompileCallSite(callSite);
             var compiledCollectionCallSite = CompileCallSite(collectionCallSite);
@@ -111,7 +111,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             descriptors.AddScoped<ServiceC>();
 
             var provider = new ServiceProvider(descriptors);
-            var callSite = provider.GetServiceCallSite(typeof(ServiceC), new HashSet<Type>());
+            var callSite = provider.GetServiceCallSite(typeof(ServiceC));
             var compiledCallSite = CompileCallSite(callSite);
 
             var serviceC = (ServiceC)compiledCallSite(provider);
@@ -130,10 +130,10 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 
             var provider = new ServiceProvider(descriptors);
 
-            var callSite1 = provider.GetServiceCallSite(typeof(ClassWithThrowingEmptyCtor), new HashSet<Type>());
+            var callSite1 = provider.GetServiceCallSite(typeof(ClassWithThrowingEmptyCtor));
             var compiledCallSite1 = CompileCallSite(callSite1);
 
-            var callSite2 = provider.GetServiceCallSite(typeof(ClassWithThrowingCtor), new HashSet<Type>());
+            var callSite2 = provider.GetServiceCallSite(typeof(ClassWithThrowingCtor));
             var compiledCallSite2 = CompileCallSite(callSite2);
 
             var ex1 = Assert.Throws<Exception>(() => compiledCallSite1(provider));

--- a/test/Microsoft.Extensions.DependencyInjection.Tests/CircularDependencyTests.cs
+++ b/test/Microsoft.Extensions.DependencyInjection.Tests/CircularDependencyTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
     public class CircularDependencyTests
     {
         [Fact]
-        public void SelfCircularDependency()
+        public void SelfCircularDependency_CannotResolve()
         {
             var serviceProvider = new ServiceCollection()
                 .AddTransient<SelfCircularDependency>()
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                 serviceProvider.GetRequiredService<SelfCircularDependency>());
 
             Assert.Equal(
-                Resources.FormatCircularDependencyException(typeof(SelfCircularDependency)),
+                Resources.FormatCannotResolveService(typeof(SelfCircularDependency), typeof(SelfCircularDependency)),
                 exception.Message);
         }
 
@@ -35,7 +35,9 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                 serviceProvider.GetRequiredService<SelfCircularDependencyGeneric<string>>());
 
             Assert.Equal(
-                Resources.FormatCircularDependencyException(typeof(SelfCircularDependencyGeneric<string>)),
+                Resources.FormatCannotResolveService(
+                    typeof(SelfCircularDependencyGeneric<string>),
+                    typeof(SelfCircularDependencyGeneric<string>)),
                 exception.Message);
         }
 
@@ -51,7 +53,9 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                 serviceProvider.GetRequiredService<SelfCircularDependencyGeneric<int>>());
 
             Assert.Equal(
-                Resources.FormatCircularDependencyException(typeof(SelfCircularDependencyGeneric<string>)),
+                Resources.FormatCannotResolveService(
+                    typeof(SelfCircularDependencyGeneric<string>),
+                    typeof(SelfCircularDependencyGeneric<string>)),
                 exception.Message);
         }
 
@@ -81,7 +85,9 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                 serviceProvider.GetRequiredService<SelfCircularDependencyWithInterface>());
 
             Assert.Equal(
-                Resources.FormatCircularDependencyException(typeof(ISelfCircularDependencyWithInterface)),
+                Resources.FormatCannotResolveService(
+                    typeof(ISelfCircularDependencyWithInterface), 
+                    typeof(SelfCircularDependencyWithInterface)),
                 exception.Message);
         }
 
@@ -97,7 +103,9 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                 serviceProvider.GetRequiredService<DirectCircularDependencyA>());
 
             Assert.Equal(
-                Resources.FormatCircularDependencyException(typeof(DirectCircularDependencyA)),
+                Resources.FormatCannotResolveService(
+                    typeof(DirectCircularDependencyA), 
+                    typeof(DirectCircularDependencyB)),
                 exception.Message);
         }
 
@@ -114,7 +122,9 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                 serviceProvider.GetRequiredService<IndirectCircularDependencyA>());
 
             Assert.Equal(
-                Resources.FormatCircularDependencyException(typeof(IndirectCircularDependencyA)),
+                Resources.FormatCannotResolveService(
+                    typeof(IndirectCircularDependencyA),
+                    typeof(IndirectCircularDependencyC)),
                 exception.Message);
         }
 

--- a/test/Microsoft.Extensions.DependencyInjection.Tests/Fakes/CircularReferences/SelfCircularDependencyGeneric.cs
+++ b/test/Microsoft.Extensions.DependencyInjection.Tests/Fakes/CircularReferences/SelfCircularDependencyGeneric.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests.Fakes
 
         }
 
-        public SelfCircularDependencyGeneric()
+        internal SelfCircularDependencyGeneric()
         {
 
         }

--- a/test/Microsoft.Extensions.DependencyInjection.Tests/ServiceLookup/ServiceTest.cs
+++ b/test/Microsoft.Extensions.DependencyInjection.Tests/ServiceLookup/ServiceTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var serviceProvider = new ServiceProvider(new[] { descriptor });
 
             // Act and Assert
-            var ex = Assert.Throws<InvalidOperationException>(() => service.CreateCallSite(serviceProvider, new HashSet<Type>()));
+            var ex = Assert.Throws<InvalidOperationException>(() => service.CreateCallSite(serviceProvider));
             Assert.Equal(expectedMessage, ex.Message);
         }
 
@@ -41,7 +41,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var serviceProvider = new ServiceProvider(new[] { descriptor });
 
             // Act
-            var callSite = service.CreateCallSite(serviceProvider, new HashSet<Type>());
+            var callSite = service.CreateCallSite(serviceProvider);
 
             // Assert
             Assert.IsType<CreateInstanceCallSite>(callSite);
@@ -63,7 +63,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             );
 
             // Act
-            var callSite = service.CreateCallSite(serviceProvider, new HashSet<Type>());
+            var callSite = service.CreateCallSite(serviceProvider);
 
             // Assert
             var constructorCallSite = Assert.IsType<ConstructorCallSite>(callSite);
@@ -83,7 +83,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             );
 
             // Act
-            var callSite = service.CreateCallSite(serviceProvider, new HashSet<Type>());
+            var callSite = service.CreateCallSite(serviceProvider);
 
             // Assert
             var constructorCallSite = Assert.IsType<ConstructorCallSite>(callSite);
@@ -102,7 +102,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var serviceProvider = new ServiceProvider(new[] { descriptor });
 
             // Act
-            var callSite = service.CreateCallSite(serviceProvider, new HashSet<Type>());
+            var callSite = service.CreateCallSite(serviceProvider);
 
             // Assert
             Assert.IsType<CreateInstanceCallSite>(callSite);
@@ -194,7 +194,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
 
             // Act
-            var callSite = service.CreateCallSite((ServiceProvider)serviceProvider, new HashSet<Type>());
+            var callSite = service.CreateCallSite((ServiceProvider)serviceProvider);
 
             // Assert
             var constructorCallSite = Assert.IsType<ConstructorCallSite>(callSite);
@@ -237,7 +237,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var service = new Service(descriptor);
 
             // Act
-            var callSite = service.CreateCallSite((ServiceProvider)serviceProvider, new HashSet<Type>());
+            var callSite = service.CreateCallSite((ServiceProvider)serviceProvider);
 
             // Assert
             var constructorCallSite = Assert.IsType<ConstructorCallSite>(callSite);
@@ -255,7 +255,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
             // Act and Assert
             var ex = Assert.Throws<InvalidOperationException>(
-                () => service.CreateCallSite(serviceProvider, new HashSet<Type>()));
+                () => service.CreateCallSite(serviceProvider));
             Assert.Equal($"Unable to resolve service for type '{typeof(IFakeService)}' while attempting to activate '{type}'.",
                 ex.Message);
         }
@@ -276,7 +276,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
             // Act and Assert
             var ex = Assert.Throws<InvalidOperationException>(
-                () => service.CreateCallSite(serviceProvider, new HashSet<Type>()));
+                () => service.CreateCallSite(serviceProvider));
             Assert.Equal($"No constructor for type '{type}' can be instantiated using services from the service container and default values.",
                 ex.Message);
         }
@@ -357,7 +357,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var expectedMessage =
                 string.Join(
                     Environment.NewLine,
-                    $"Unable to activate type '{type}'. The following constructors are ambigious:",
+                    $"Unable to activate type '{type}'. The following constructors are ambiguous:",
                     GetConstructor(type, expectedConstructorParameterTypes[0]),
                     GetConstructor(type, expectedConstructorParameterTypes[1]));
             var descriptor = new ServiceDescriptor(type, type, ServiceLifetime.Transient);
@@ -365,7 +365,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
             // Act and Assert
             var ex = Assert.Throws<InvalidOperationException>(
-                () => service.CreateCallSite((ServiceProvider)serviceProvider, new HashSet<Type>()));
+                () => service.CreateCallSite((ServiceProvider)serviceProvider));
             Assert.Equal(expectedMessage, ex.Message);
         }
 
@@ -374,7 +374,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             // Arrange
             var type = typeof(TypeWithGenericServices);
-            var expectedMessage = $"Unable to activate type '{type}'. The following constructors are ambigious:";
+            var expectedMessage = $"Unable to activate type '{type}'. The following constructors are ambiguous:";
             var descriptor = new ServiceDescriptor(type, type, ServiceLifetime.Transient);
             var serviceProvider = GetServiceProvider(
                 new ServiceDescriptor(typeof(IFakeService), typeof(FakeService), ServiceLifetime.Transient),
@@ -385,7 +385,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
             // Act and Assert
             var ex = Assert.Throws<InvalidOperationException>(
-                () => service.CreateCallSite(serviceProvider, new HashSet<Type>()));
+                () => service.CreateCallSite(serviceProvider));
             Assert.StartsWith(expectedMessage, ex.Message);
         }
 


### PR DESCRIPTION
- Correct 'ambigious' typo (should be 'ambiguous')
- Instead of circular dependency detection for constructors or
  StackOverFlowExceptions for factories, pull out each currently resolving
  service from the ServiceEntry. This allows factories and constructors
  to access the other services registered under the same type
- Part of implementing this also requires that service resolution
  callsites be cached by the actual service, rather than just the type