### PR TITLE
Added LightInject to the list of containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,6 @@ http://alexmg.com/autofac-packages-for-visual-studio-2015-and-asp-net-5/
 
 * **StructureMap**
 https://github.com/structuremap/structuremap.dnx
+
+* **LightInject**
+https://github.com/seesharper/LightInject.Microsoft.DependencyInjection


### PR DESCRIPTION
I have just completed the adapter for LightInject and it would be nice to have a link to the repo in the readme file.