### PR TITLE
Make DependencyInjection package use NET46 compatible Ref …

### DIFF
--- a/src/Microsoft.Extensions.DependencyInjection.Abstractions/project.json
+++ b/src/Microsoft.Extensions.DependencyInjection.Abstractions/project.json
@@ -21,13 +21,13 @@
     "net451": {},
     "dotnet5.4": {
       "dependencies": {
-        "System.ComponentModel": "4.0.1-*",
-        "System.Diagnostics.Debug": "4.0.11-*",
-        "System.Globalization": "4.0.11-*",
-        "System.Linq": "4.1.0-*",
-        "System.Linq.Expressions": "4.0.11-*",
-        "System.Reflection": "4.1.0-*",
-        "System.Resources.ResourceManager": "4.0.1-*"
+        "System.ComponentModel": "4.0.0-*",
+        "System.Diagnostics.Debug": "4.0.10-*",
+        "System.Globalization": "4.0.10-*",
+        "System.Linq": "4.0.0-*",
+        "System.Linq.Expressions": "4.0.10-*",
+        "System.Reflection": "4.0.10-*",
+        "System.Resources.ResourceManager": "4.0.0-*"
       }
     }
   }

--- a/src/Microsoft.Extensions.DependencyInjection/project.json
+++ b/src/Microsoft.Extensions.DependencyInjection/project.json
@@ -18,10 +18,10 @@
     "net451": {},
     "dotnet5.4": {
       "dependencies": {
-        "System.Collections": "4.0.11-*",
-        "System.Collections.Concurrent": "4.0.12-*",
-        "System.Threading": "4.0.11-*",
-        "System.Threading.Tasks": "4.0.11-*"
+        "System.Collections": "4.0.10-*",
+        "System.Collections.Concurrent": "4.0.10-*",
+        "System.Threading": "4.0.10-*",
+        "System.Threading.Tasks": "4.0.10-*"
       }
     }
   }


### PR DESCRIPTION
…Assemblies.

This has no functionality impact but allows the assembly to be compatible with more frameworks.