### PR TITLE
Don't reference facades in NuSpec

### DIFF
--- a/src/Microsoft.Extensions.DependencyInjection.Specification.Tests/project.json
+++ b/src/Microsoft.Extensions.DependencyInjection.Specification.Tests/project.json
@@ -21,8 +21,8 @@
   "frameworks": {
     "net451": {
       "frameworkAssemblies": {
-        "System.Runtime": "",
-        "System.Threading.Tasks": ""
+        "System.Runtime": { "type": "build" },
+        "System.Threading.Tasks": { "type": "build" }
       }
     },
     "netstandard1.3": {


### PR DESCRIPTION
These can be removed entirely after dotnet/cli#164
