### PR TITLE
Optimize expression compilation memory usage

### DIFF
--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteExpressionBuilder.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteExpressionBuilder.cs
@@ -1,0 +1,260 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Threading;
+
+namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
+{
+    internal class CallSiteExpressionBuilder
+    {
+        private static readonly MethodInfo CaptureDisposableMethodInfo = GetMethodInfo<Func<ServiceProvider, object, object>>((a, b) => a.CaptureDisposable(b));
+        private static readonly MethodInfo TryGetValueMethodInfo = GetMethodInfo<Func<IDictionary<object, object>, object, object, bool>>((a, b, c) => a.TryGetValue(b, out c));
+        private static readonly MethodInfo AddMethodInfo = GetMethodInfo<Action<IDictionary<object, object>, object, object>>((a, b, c) => a.Add(b, c));
+        private static readonly MethodInfo MonitorEnterMethodInfo = GetMethodInfo<Action<object, bool>>((lockObj, lockTaken) => Monitor.Enter(lockObj, ref lockTaken));
+        private static readonly MethodInfo MonitorExitMethodInfo = GetMethodInfo<Action<object>>(lockObj => Monitor.Exit(lockObj));
+
+        private readonly ParameterExpression _providerParameter = Expression.Parameter(typeof(ServiceProvider));
+
+        private readonly List<Expression> _initializations = new List<Expression>();
+        private readonly List<ParameterExpression> _variables = new List<ParameterExpression>();
+        private readonly List<Expression> _locks = new List<Expression>();
+
+        private readonly Dictionary<Expression, ParameterExpression> _resolvedServices = new Dictionary<Expression, ParameterExpression>();
+        private readonly Dictionary<Expression, LambdaExpression> _captureDisposable = new Dictionary<Expression, LambdaExpression>();
+
+        private ParameterExpression _rootVariable;
+
+        public Expression<Func<ServiceProvider, object>> Build(IServiceCallSite callSite)
+        {
+            var serviceExpression = BuildExpression(callSite, _providerParameter);
+
+            List<Expression> body = new List<Expression>();
+            body.AddRange(_initializations);
+            foreach (var expression in _locks)
+            {
+                serviceExpression = Lock(serviceExpression, expression);
+            }
+            body.Add(serviceExpression);
+
+            return Expression.Lambda<Func<ServiceProvider, object>>(
+                Expression.Block(_variables, body),
+                _providerParameter);
+        }
+
+        private Expression BuildExpression(IServiceCallSite callSite, ParameterExpression provider)
+        {
+            var factoryService = callSite as FactoryService;
+            if (factoryService != null)
+            {
+                return BuildFactoryService(factoryService, provider);
+            }
+            var closedIEnumerableCallSite = callSite as ClosedIEnumerableCallSite;
+            if (closedIEnumerableCallSite != null)
+            {
+                return BuildClosedIEnumerable(closedIEnumerableCallSite, provider);
+            }
+            var constructorCallSite = callSite as ConstructorCallSite;
+            if (constructorCallSite != null)
+            {
+                return BuildConstructor(constructorCallSite, provider);
+            }
+            var transientCallSite = callSite as TransientCallSite;
+            if (transientCallSite != null)
+            {
+                return BuildTransient(transientCallSite, provider);
+            }
+            var singletonCallSite = callSite as SingletonCallSite;
+            if (singletonCallSite != null)
+            {
+                return BuildScoped(singletonCallSite, GetRootProvider());
+            }
+            var scopedCallSite = callSite as ScopedCallSite;
+            if (scopedCallSite != null)
+            {
+                return BuildScoped(scopedCallSite, provider);
+            }
+            var constantCallSite = callSite as ConstantCallSite;
+            if (constantCallSite != null)
+            {
+                return Expression.Constant(constantCallSite.DefaultValue);
+            }
+            var createInstanceCallSite = callSite as CreateInstanceCallSite;
+            if (createInstanceCallSite != null)
+            {
+                return Expression.New(createInstanceCallSite.Descriptor.ImplementationType);
+            }
+            var instanceCallSite = callSite as InstanceService;
+            if (instanceCallSite != null)
+            {
+                return Expression.Constant(
+                    instanceCallSite.Descriptor.ImplementationInstance,
+                    instanceCallSite.Descriptor.ServiceType);
+            }
+            var serviceProviderService = callSite as ServiceProviderService;
+            if (serviceProviderService != null)
+            {
+                return provider;
+            }
+            var emptyIEnumerableCallSite = callSite as EmptyIEnumerableCallSite;
+            if (emptyIEnumerableCallSite != null)
+            {
+                return Expression.Constant(
+                    emptyIEnumerableCallSite.ServiceInstance,
+                    emptyIEnumerableCallSite.ServiceType);
+            }
+            var serviceScopeService = callSite as ServiceScopeService;
+            if (serviceScopeService != null)
+            {
+                return Expression.New(typeof(ServiceScopeFactory).GetTypeInfo()
+                        .DeclaredConstructors
+                        .Single(),
+                    provider);
+            }
+            throw new NotSupportedException("Call site type is not supported");
+        }
+
+        public Expression BuildFactoryService(FactoryService factoryService, ParameterExpression provider)
+        {
+            return Expression.Invoke(Expression.Constant(factoryService.Descriptor.ImplementationFactory), provider);
+        }
+
+        public Expression BuildClosedIEnumerable(ClosedIEnumerableCallSite callSite, ParameterExpression provider)
+        {
+            return Expression.NewArrayInit(
+                callSite.ItemType,
+                callSite.ServiceCallSites.Select(cs =>
+                    Expression.Convert(
+                        BuildExpression(cs, provider),
+                        callSite.ItemType)));
+        }
+
+        public Expression BuildTransient(TransientCallSite callSite, ParameterExpression provider)
+        {
+            return Expression.Invoke(GetCaptureDisposable(provider),
+                BuildExpression(callSite.Service, provider));
+        }
+
+        public Expression BuildConstructor(ConstructorCallSite callSite, ParameterExpression provider)
+        {
+            var parameters = callSite.ConstructorInfo.GetParameters();
+            return Expression.New(
+                callSite.ConstructorInfo,
+                callSite.ParameterCallSites.Select((c, index) =>
+                        Expression.Convert(BuildExpression(c, provider), parameters[index].ParameterType)));
+        }
+
+        public virtual Expression BuildScoped(ScopedCallSite callSite, ParameterExpression provider)
+        {
+            var keyExpression = Expression.Constant(
+                callSite.Key,
+                typeof(object));
+
+            var resolvedExpression = Expression.Variable(typeof(object), "resolved");
+
+            var resolvedServices = GetResolvedServices(provider);
+
+            var tryGetValueExpression = Expression.Call(
+                resolvedServices,
+                TryGetValueMethodInfo,
+                keyExpression,
+                resolvedExpression);
+
+            var assignExpression = Expression.Assign(
+                resolvedExpression, BuildExpression(callSite.ServiceCallSite, provider));
+
+            var addValueExpression = Expression.Call(
+                resolvedServices,
+                AddMethodInfo,
+                keyExpression,
+                resolvedExpression);
+
+            var blockExpression = Expression.Block(
+                typeof(object),
+                new[] {
+                    resolvedExpression
+                },
+                Expression.IfThen(
+                    Expression.Not(tryGetValueExpression),
+                    Expression.Block(assignExpression, addValueExpression)),
+                resolvedExpression);
+
+            return blockExpression;
+        }
+
+        private static MethodInfo GetMethodInfo<T>(Expression<T> expr)
+        {
+            var mc = (MethodCallExpression)expr.Body;
+            return mc.Method;
+        }
+
+        public Expression GetCaptureDisposable(ParameterExpression provider)
+        {
+            LambdaExpression captureDisposableLambda;
+            if (!_captureDisposable.TryGetValue(provider, out captureDisposableLambda))
+            {
+                var parameter = Expression.Parameter(typeof(object));
+                 captureDisposableLambda = Expression.Lambda(
+                    Expression.Call(provider, CaptureDisposableMethodInfo, parameter), parameter);
+                _captureDisposable.Add(provider, captureDisposableLambda);
+            }
+
+            return captureDisposableLambda;
+        }
+
+        public Expression GetResolvedServices(ParameterExpression provider)
+        {
+            ParameterExpression resolvedServicesVariable;
+            if (!_resolvedServices.TryGetValue(provider, out resolvedServicesVariable))
+            {
+                var resolvedServicesExpression = Expression.Field(
+                    provider,
+                    "_resolvedServices");
+
+                resolvedServicesVariable = Expression.Variable(typeof(IDictionary<object, object>),
+                    provider.Name + "resolvedServices");
+                var resolvedServicesVariableAssignment = Expression.Assign(resolvedServicesVariable,
+                    resolvedServicesExpression);
+
+                _locks.Add(resolvedServicesVariable);
+                _variables.Add(resolvedServicesVariable);
+                _initializations.Add(resolvedServicesVariableAssignment);
+                _resolvedServices.Add(provider, resolvedServicesVariable);
+            }
+
+            return resolvedServicesVariable;
+        }
+
+        public ParameterExpression GetRootProvider()
+        {
+            if (_rootVariable == null)
+            {
+                var rootExpression = Expression.Field(_providerParameter, "_root");
+                _rootVariable = Expression.Variable(typeof(ServiceProvider), "root");
+
+                _variables.Add(_rootVariable);
+                _initializations.Add(Expression.Assign(_rootVariable, rootExpression));
+            }
+            return _rootVariable;
+        }
+
+        private static Expression Lock(Expression body, Expression syncVariable)
+        {
+            // The C# compiler would copy the lock object to guard against mutation.
+            // We don't, since we know the lock object is readonly.
+            var lockWasTaken = Expression.Variable(typeof(bool), "lockWasTaken");
+
+            var monitorEnter = Expression.Call(MonitorEnterMethodInfo, syncVariable, lockWasTaken);
+            var monitorExit = Expression.Call(MonitorExitMethodInfo, syncVariable);
+
+            var tryBody = Expression.Block(monitorEnter, body);
+            var finallyBody = Expression.IfThen(lockWasTaken, monitorExit);
+
+            return Expression.Block(
+                typeof(object),
+                new[] { lockWasTaken },
+                Expression.TryFinally(tryBody, finallyBody));
+        }
+    }
+}

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteExpressionBuilder.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteExpressionBuilder.cs
@@ -10,7 +10,7 @@ using System.Threading;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
-    internal class CallSiteExpressionBuilder: CallSiteVisitor<ParameterExpression, Expression>
+    internal class CallSiteExpressionBuilder : CallSiteVisitor<ParameterExpression, Expression>
     {
         private static readonly MethodInfo CaptureDisposableMethodInfo = GetMethodInfo<Func<ServiceProvider, object, object>>((a, b) => a.CaptureDisposable(b));
         private static readonly MethodInfo TryGetValueMethodInfo = GetMethodInfo<Func<IDictionary<object, object>, object, object, bool>>((a, b, c) => a.TryGetValue(b, out c));

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteExpressionBuilder.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteExpressionBuilder.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             var serviceExpression = VisitCallSite(callSite, ProviderParameter);
 
-            List<Expression> body = new List<Expression>();
+            var body = new List<Expression>();
             if (_requiresResolvedServices)
             {
                 body.Add(ResolvedServicesVariableAssignment);

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteExpressionBuilder.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteExpressionBuilder.cs
@@ -21,9 +21,9 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             GetMethodInfo<Func<CallSiteRuntimeResolver, IServiceCallSite, ServiceProvider, object>>((r, c, p) => r.Resolve(c, p));
 
         private static readonly ParameterExpression ProviderParameter = Expression.Parameter(typeof(ServiceProvider));
+
         private static readonly ParameterExpression ResolvedServices = Expression.Variable(typeof(IDictionary<object, object>),
             ProviderParameter.Name + "resolvedServices");
-
         private static readonly BinaryExpression ResolvedServicesVariableAssignment =
             Expression.Assign(ResolvedServices,
                 Expression.Property(ProviderParameter, nameof(ServiceProvider.ResolvedServices)));

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteRuntimeResolver.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteRuntimeResolver.cs
@@ -3,7 +3,7 @@ using System.Runtime.ExceptionServices;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
-    class CallSiteRuntimeResolver : CallSiteVisitor<ServiceProvider, object>
+    internal class CallSiteRuntimeResolver : CallSiteVisitor<ServiceProvider, object>
     {
         public object Resolve(IServiceCallSite callSite, ServiceProvider provider)
         {

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteRuntimeResolver.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteRuntimeResolver.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Runtime.ExceptionServices;
+
+namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
+{
+    class CallSiteRuntimeResolver : CallSiteVisitor<ServiceProvider, object>
+    {
+        public object Resolve(IServiceCallSite callSite, ServiceProvider provider)
+        {
+            return VisitCallSite(callSite, provider);
+        }
+
+        protected override object VisitTransient(TransientCallSite transientCallSite, ServiceProvider provider)
+        {
+            return provider.CaptureDisposable(
+                VisitCallSite(transientCallSite.Service, provider));
+        }
+
+        protected override object VisitConstructor(ConstructorCallSite constructorCallSite, ServiceProvider provider)
+        {
+            object[] parameterValues = new object[constructorCallSite.ParameterCallSites.Length];
+            for (var index = 0; index < parameterValues.Length; index++)
+            {
+                parameterValues[index] = VisitCallSite(constructorCallSite.ParameterCallSites[index], provider);
+            }
+
+            try
+            {
+                return constructorCallSite.ConstructorInfo.Invoke(parameterValues);
+            }
+            catch (Exception ex) when (ex.InnerException != null)
+            {
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                // The above line will always throw, but the compiler requires we throw explicitly.
+                throw;
+            }
+        }
+
+        protected override object VisitSingleton(SingletonCallSite singletonCallSite, ServiceProvider provider)
+        {
+            return VisitScoped(singletonCallSite, provider.Root);
+        }
+
+        protected override object VisitScoped(ScopedCallSite scopedCallSite, ServiceProvider provider)
+        {
+            object resolved;
+            lock (provider.ResolvedServices)
+            {
+                if (!provider.ResolvedServices.TryGetValue(scopedCallSite.Key, out resolved))
+                {
+                    resolved = VisitCallSite(scopedCallSite.ServiceCallSite, provider);
+                    provider.ResolvedServices.Add(scopedCallSite.Key, resolved);
+                }
+            }
+            return resolved;
+        }
+
+        protected override object VisitConstant(ConstantCallSite constantCallSite, ServiceProvider provider)
+        {
+            return constantCallSite.DefaultValue;
+        }
+
+        protected override object VisitCreateInstance(CreateInstanceCallSite createInstanceCallSite, ServiceProvider provider)
+        {
+            try
+            {
+                return Activator.CreateInstance(createInstanceCallSite.Descriptor.ImplementationType);
+            }
+            catch (Exception ex) when (ex.InnerException != null)
+            {
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                // The above line will always throw, but the compiler requires we throw explicitly.
+                throw;
+            }
+        }
+
+        protected override object VisitInstanceService(InstanceService instanceCallSite, ServiceProvider provider)
+        {
+            return instanceCallSite.Descriptor.ImplementationInstance;
+        }
+
+        protected override object VisitServiceProviderService(ServiceProviderService serviceProviderService, ServiceProvider provider)
+        {
+            return provider;
+        }
+
+        protected override object VisitEmptyIEnumerable(EmptyIEnumerableCallSite emptyIEnumerableCallSite, ServiceProvider provider)
+        {
+            return emptyIEnumerableCallSite.ServiceInstance;
+        }
+
+        protected override object VisitServiceScopeService(ServiceScopeService serviceScopeService, ServiceProvider provider)
+        {
+            return new ServiceScopeFactory(provider);
+        }
+
+        protected override object VisitClosedIEnumerable(ClosedIEnumerableCallSite closedIEnumerableCallSite, ServiceProvider provider)
+        {
+            var array = Array.CreateInstance(
+                closedIEnumerableCallSite.ItemType,
+                closedIEnumerableCallSite.ServiceCallSites.Length);
+
+            for (var index = 0; index < closedIEnumerableCallSite.ServiceCallSites.Length; index++)
+            {
+                var value = VisitCallSite(closedIEnumerableCallSite.ServiceCallSites[index], provider);
+                array.SetValue(value, index);
+            }
+            return array;
+        }
+
+        protected override object VisitFactoryService(FactoryService factoryService, ServiceProvider provider)
+        {
+            return factoryService.Descriptor.ImplementationFactory(provider);
+        }
+    }
+}

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteVisitor.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteVisitor.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             {
                 return VisitServiceScopeService(serviceScopeService, argument);
             }
-            throw new NotSupportedException("Call site type is not supported");
+            throw new NotSupportedException($"Call site type {callSite.GetType()} is not supported");
         }
 
         protected abstract TResult VisitTransient(TransientCallSite transientCallSite, TArgument argument);

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteVisitor.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteVisitor.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal abstract class CallSiteVisitor<TArgument, TResult>
     {
-        protected virtual TResult VisitExpression(IServiceCallSite callSite, TArgument argument)
+        protected virtual TResult VisitCallSite(IServiceCallSite callSite, TArgument argument)
         {
             var factoryService = callSite as FactoryService;
             if (factoryService != null)

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteVisitor.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteVisitor.cs
@@ -1,0 +1,96 @@
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
+{
+    internal abstract class CallSiteVisitor<TArgument, TResult>
+    {
+        protected virtual TResult VisitExpression(IServiceCallSite callSite, TArgument argument)
+        {
+            var factoryService = callSite as FactoryService;
+            if (factoryService != null)
+            {
+                return VisitFactoryService(factoryService, argument);
+            }
+            var closedIEnumerableCallSite = callSite as ClosedIEnumerableCallSite;
+            if (closedIEnumerableCallSite != null)
+            {
+                return VisitClosedIEnumerable(closedIEnumerableCallSite, argument);
+            }
+            var constructorCallSite = callSite as ConstructorCallSite;
+            if (constructorCallSite != null)
+            {
+                return VisitConstructor(constructorCallSite, argument);
+            }
+            var transientCallSite = callSite as TransientCallSite;
+            if (transientCallSite != null)
+            {
+                return VisitTransient(transientCallSite, argument);
+            }
+            var singletonCallSite = callSite as SingletonCallSite;
+            if (singletonCallSite != null)
+            {
+                return VisitSingleton(singletonCallSite, argument);
+            }
+            var scopedCallSite = callSite as ScopedCallSite;
+            if (scopedCallSite != null)
+            {
+                return VisitScoped(scopedCallSite, argument);
+            }
+            var constantCallSite = callSite as ConstantCallSite;
+            if (constantCallSite != null)
+            {
+                return VisitConstant(constantCallSite, argument);
+            }
+            var createInstanceCallSite = callSite as CreateInstanceCallSite;
+            if (createInstanceCallSite != null)
+            {
+                return VisitCreateInstance(createInstanceCallSite, argument);
+            }
+            var instanceCallSite = callSite as InstanceService;
+            if (instanceCallSite != null)
+            {
+                return VisitInstanceService(instanceCallSite, argument);
+            }
+            var serviceProviderService = callSite as ServiceProviderService;
+            if (serviceProviderService != null)
+            {
+                return VisitServiceProviderService(serviceProviderService, argument);
+            }
+            var emptyIEnumerableCallSite = callSite as EmptyIEnumerableCallSite;
+            if (emptyIEnumerableCallSite != null)
+            {
+                return VisitEmptyIEnumerable(emptyIEnumerableCallSite, argument);
+            }
+            var serviceScopeService = callSite as ServiceScopeService;
+            if (serviceScopeService != null)
+            {
+                return VisitServiceScopeService(serviceScopeService, argument);
+            }
+            throw new NotSupportedException("Call site type is not supported");
+        }
+
+        protected abstract TResult VisitTransient(TransientCallSite transientCallSite, TArgument argument);
+
+        protected abstract TResult VisitConstructor(ConstructorCallSite constructorCallSite, TArgument argument);
+
+        protected abstract TResult VisitSingleton(SingletonCallSite singletonCallSite, TArgument argument);
+
+        protected abstract TResult VisitScoped(ScopedCallSite scopedCallSite, TArgument argument);
+
+        protected abstract TResult VisitConstant(ConstantCallSite constantCallSite, TArgument argument);
+
+        protected abstract TResult VisitCreateInstance(CreateInstanceCallSite createInstanceCallSite, TArgument argument);
+
+        protected abstract TResult VisitInstanceService(InstanceService instanceCallSite, TArgument argument);
+
+        protected abstract TResult VisitServiceProviderService(ServiceProviderService serviceProviderService, TArgument argument);
+
+        protected abstract TResult VisitEmptyIEnumerable(EmptyIEnumerableCallSite emptyIEnumerableCallSite, TArgument argument);
+
+        protected abstract TResult VisitServiceScopeService(ServiceScopeService serviceScopeService, TArgument argument);
+
+        protected abstract TResult VisitClosedIEnumerable(ClosedIEnumerableCallSite closedIEnumerableCallSite, TArgument argument);
+
+        protected abstract TResult VisitFactoryService(FactoryService factoryService, TArgument argument);
+    }
+}

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ClosedIEnumerableCallSite.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ClosedIEnumerableCallSite.cs
@@ -1,9 +1,11 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
 using System;
-using System.Linq.Expressions;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
-    class ClosedIEnumerableCallSite : IServiceCallSite
+    internal class ClosedIEnumerableCallSite : IServiceCallSite
     {
         internal Type ItemType { get; }
         internal IServiceCallSite[] ServiceCallSites { get; }
@@ -12,16 +14,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             ItemType = itemType;
             ServiceCallSites = serviceCallSites;
-        }
-
-        public object Invoke(ServiceProvider provider)
-        {
-            var array = Array.CreateInstance(ItemType, ServiceCallSites.Length);
-            for (var index = 0; index < ServiceCallSites.Length; index++)
-            {
-                array.SetValue(ServiceCallSites[index].Invoke(provider), index);
-            }
-            return array;
         }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ClosedIEnumerableCallSite.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ClosedIEnumerableCallSite.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Linq.Expressions;
+
+namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
+{
+    class ClosedIEnumerableCallSite : IServiceCallSite
+    {
+        internal Type ItemType { get; }
+        internal IServiceCallSite[] ServiceCallSites { get; }
+
+        public ClosedIEnumerableCallSite(Type itemType, IServiceCallSite[] serviceCallSites)
+        {
+            ItemType = itemType;
+            ServiceCallSites = serviceCallSites;
+        }
+
+        public object Invoke(ServiceProvider provider)
+        {
+            var array = Array.CreateInstance(ItemType, ServiceCallSites.Length);
+            for (var index = 0; index < ServiceCallSites.Length; index++)
+            {
+                array.SetValue(ServiceCallSites[index].Invoke(provider), index);
+            }
+            return array;
+        }
+    }
+}

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ClosedIEnumerableService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ClosedIEnumerableService.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
@@ -35,39 +34,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 list.Add(provider.GetResolveCallSite(service, callSiteChain));
                 service = service.Next;
             }
-            return new CallSite(_itemType, list.ToArray());
+            return new ClosedIEnumerableCallSite(_itemType, list.ToArray());
         }
 
-        private class CallSite : IServiceCallSite
-        {
-            private readonly Type _itemType;
-            private readonly IServiceCallSite[] _serviceCallSites;
-
-            public CallSite(Type itemType, IServiceCallSite[] serviceCallSites)
-            {
-                _itemType = itemType;
-                _serviceCallSites = serviceCallSites;
-            }
-
-            public object Invoke(ServiceProvider provider)
-            {
-                var array = Array.CreateInstance(_itemType, _serviceCallSites.Length);
-                for (var index = 0; index < _serviceCallSites.Length; index++)
-                {
-                    array.SetValue(_serviceCallSites[index].Invoke(provider), index);
-                }
-                return array;
-            }
-
-            public Expression Build(Expression provider)
-            {
-                return Expression.NewArrayInit(
-                    _itemType,
-                    _serviceCallSites.Select(callSite =>
-                        Expression.Convert(
-                            callSite.Build(provider),
-                            _itemType)));
-            }
-        }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ConstantCallSite.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ConstantCallSite.cs
@@ -11,10 +11,5 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             DefaultValue = defaultValue;
         }
-
-        public object Invoke(ServiceProvider provider)
-        {
-            return DefaultValue;
-        }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ConstructorCallSite.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ConstructorCallSite.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 
@@ -11,28 +9,26 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal class ConstructorCallSite : IServiceCallSite
     {
-        private readonly ConstructorInfo _constructorInfo;
-        private readonly IServiceCallSite[] _parameterCallSites;
+        internal ConstructorInfo ConstructorInfo { get; }
+        internal IServiceCallSite[] ParameterCallSites { get; }
 
         public ConstructorCallSite(ConstructorInfo constructorInfo, IServiceCallSite[] parameterCallSites)
         {
-            _constructorInfo = constructorInfo;
-            _parameterCallSites = parameterCallSites;
+            ConstructorInfo = constructorInfo;
+            ParameterCallSites = parameterCallSites;
         }
-
-        public ConstructorInfo Constructor => _constructorInfo;
 
         public object Invoke(ServiceProvider provider)
         {
-            object[] parameterValues = new object[_parameterCallSites.Length];
+            object[] parameterValues = new object[ParameterCallSites.Length];
             for (var index = 0; index < parameterValues.Length; index++)
             {
-                parameterValues[index] = _parameterCallSites[index].Invoke(provider);
+                parameterValues[index] = ParameterCallSites[index].Invoke(provider);
             }
 
             try
             {
-                return _constructorInfo.Invoke(parameterValues);
+                return ConstructorInfo.Invoke(parameterValues);
             }
             catch (Exception ex) when (ex.InnerException != null)
             {
@@ -40,17 +36,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 // The above line will always throw, but the compiler requires we throw explicitly.
                 throw;
             }
-        }
-
-        public Expression Build(Expression provider)
-        {
-            var parameters = _constructorInfo.GetParameters();
-            return Expression.New(
-                _constructorInfo,
-                _parameterCallSites.Select((callSite, index) =>
-                    Expression.Convert(
-                        callSite.Build(provider),
-                        parameters[index].ParameterType)));
         }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ConstructorCallSite.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ConstructorCallSite.cs
@@ -17,25 +17,5 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             ConstructorInfo = constructorInfo;
             ParameterCallSites = parameterCallSites;
         }
-
-        public object Invoke(ServiceProvider provider)
-        {
-            object[] parameterValues = new object[ParameterCallSites.Length];
-            for (var index = 0; index < parameterValues.Length; index++)
-            {
-                parameterValues[index] = ParameterCallSites[index].Invoke(provider);
-            }
-
-            try
-            {
-                return ConstructorInfo.Invoke(parameterValues);
-            }
-            catch (Exception ex) when (ex.InnerException != null)
-            {
-                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                // The above line will always throw, but the compiler requires we throw explicitly.
-                throw;
-            }
-        }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CreateInstanceCallSite.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CreateInstanceCallSite.cs
@@ -2,25 +2,24 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq.Expressions;
 using System.Runtime.ExceptionServices;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal class CreateInstanceCallSite : IServiceCallSite
     {
-        private readonly ServiceDescriptor _descriptor;
+        internal ServiceDescriptor Descriptor { get; }
 
         public CreateInstanceCallSite(ServiceDescriptor descriptor)
         {
-            _descriptor = descriptor;
+            Descriptor = descriptor;
         }
 
         public object Invoke(ServiceProvider provider)
         {
             try
             {
-                return Activator.CreateInstance(_descriptor.ImplementationType);
+                return Activator.CreateInstance(Descriptor.ImplementationType);
             }
             catch (Exception ex) when (ex.InnerException != null)
             {
@@ -28,11 +27,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 // The above line will always throw, but the compiler requires we throw explicitly.
                 throw;
             }
-        }
-
-        public Expression Build(Expression provider)
-        {
-            return Expression.New(_descriptor.ImplementationType);
         }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CreateInstanceCallSite.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CreateInstanceCallSite.cs
@@ -14,19 +14,5 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             Descriptor = descriptor;
         }
-
-        public object Invoke(ServiceProvider provider)
-        {
-            try
-            {
-                return Activator.CreateInstance(Descriptor.ImplementationType);
-            }
-            catch (Exception ex) when (ex.InnerException != null)
-            {
-                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                // The above line will always throw, but the compiler requires we throw explicitly.
-                throw;
-            }
-        }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/EmptyIEnumerableCallSite.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/EmptyIEnumerableCallSite.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
+{
+    internal class EmptyIEnumerableCallSite : IServiceCallSite
+    {
+        internal object ServiceInstance { get; }
+        internal Type ServiceType { get; }
+
+        public EmptyIEnumerableCallSite(Type serviceType, object serviceInstance)
+        {
+            ServiceType = serviceType;
+            ServiceInstance = serviceInstance;
+        }
+
+        public object Invoke(ServiceProvider provider)
+        {
+            return ServiceInstance;
+        }
+    }
+}

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/EmptyIEnumerableCallSite.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/EmptyIEnumerableCallSite.cs
@@ -15,10 +15,5 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             ServiceType = serviceType;
             ServiceInstance = serviceInstance;
         }
-
-        public object Invoke(ServiceProvider provider)
-        {
-            return ServiceInstance;
-        }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/FactoryService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/FactoryService.cs
@@ -3,24 +3,23 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal class FactoryService : IService, IServiceCallSite
     {
-        private readonly ServiceDescriptor _descriptor;
+        internal ServiceDescriptor Descriptor { get; }
 
         public FactoryService(ServiceDescriptor descriptor)
         {
-            _descriptor = descriptor;
+            Descriptor = descriptor;
         }
 
         public IService Next { get; set; }
 
         public ServiceLifetime Lifetime
         {
-            get { return _descriptor.Lifetime; }
+            get { return Descriptor.Lifetime; }
         }
 
         public IServiceCallSite CreateCallSite(ServiceProvider provider, ISet<Type> callSiteChain)
@@ -30,15 +29,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         public object Invoke(ServiceProvider provider)
         {
-            return _descriptor.ImplementationFactory(provider);
-        }
-
-        public Expression Build(Expression provider)
-        {
-            Expression<Func<IServiceProvider, object>> factory =
-                serviceProvider => _descriptor.ImplementationFactory(serviceProvider);
-
-            return Expression.Invoke(factory, provider);
+            return Descriptor.ImplementationFactory(provider);
         }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/FactoryService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/FactoryService.cs
@@ -26,10 +26,5 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             return this;
         }
-
-        public object Invoke(ServiceProvider provider)
-        {
-            return Descriptor.ImplementationFactory(provider);
-        }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/IService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/IService.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
-    internal interface IService
+    interface IService
     {
         IService Next { get; set; }
 

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/IService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/IService.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
-    interface IService
+    internal interface IService
     {
         IService Next { get; set; }
 

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/IServiceCallSite.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/IServiceCallSite.cs
@@ -6,8 +6,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     /// <summary>
     /// Summary description for IServiceCallSite
     /// </summary>
-    interface IServiceCallSite
+    internal interface IServiceCallSite
     {
-        object Invoke(ServiceProvider provider);
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/IServiceCallSite.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/IServiceCallSite.cs
@@ -1,17 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Linq.Expressions;
-
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     /// <summary>
     /// Summary description for IServiceCallSite
     /// </summary>
-    internal interface IServiceCallSite
+    interface IServiceCallSite
     {
         object Invoke(ServiceProvider provider);
-
-        Expression Build(Expression provider);
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/InstanceService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/InstanceService.cs
@@ -29,10 +29,5 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             return this;
         }
-
-        public object Invoke(ServiceProvider provider)
-        {
-            return Descriptor.ImplementationInstance;
-        }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/InstanceService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/InstanceService.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
@@ -12,18 +11,18 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     /// </summary>
     internal class InstanceService : IService, IServiceCallSite
     {
-        private readonly ServiceDescriptor _descriptor;
+        internal ServiceDescriptor Descriptor { get; }
 
         public InstanceService(ServiceDescriptor descriptor)
         {
-            _descriptor = descriptor;
+            Descriptor = descriptor;
         }
 
         public IService Next { get; set; }
 
         public ServiceLifetime Lifetime
         {
-            get { return _descriptor.Lifetime; }
+            get { return Descriptor.Lifetime; }
         }
 
         public IServiceCallSite CreateCallSite(ServiceProvider provider, ISet<Type> callSiteChain)
@@ -33,12 +32,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         public object Invoke(ServiceProvider provider)
         {
-            return _descriptor.ImplementationInstance;
-        }
-
-        public Expression Build(Expression provider)
-        {
-            return Expression.Constant(_descriptor.ImplementationInstance, _descriptor.ServiceType);
+            return Descriptor.ImplementationInstance;
         }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ScopedCallSite.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ScopedCallSite.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+
+namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
+{
+    class ScopedCallSite : IServiceCallSite
+    {
+        internal IService Key { get; }
+        internal IServiceCallSite ServiceCallSite { get; }
+
+        public ScopedCallSite(IService key, IServiceCallSite serviceCallSite)
+        {
+            Key = key;
+            ServiceCallSite = serviceCallSite;
+        }
+
+        public virtual object Invoke(ServiceProvider provider)
+        {
+            object resolved;
+            lock (provider._resolvedServices)
+            {
+                if (!provider._resolvedServices.TryGetValue(Key, out resolved))
+                {
+                    resolved = ServiceCallSite.Invoke(provider);
+                    provider._resolvedServices.Add(Key, resolved);
+                }
+            }
+            return resolved;
+        }
+    }
+}

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ScopedCallSite.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ScopedCallSite.cs
@@ -1,12 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Linq.Expressions;
-
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
-    class ScopedCallSite : IServiceCallSite
+    internal class ScopedCallSite : IServiceCallSite
     {
         internal IService Key { get; }
         internal IServiceCallSite ServiceCallSite { get; }
@@ -15,20 +12,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             Key = key;
             ServiceCallSite = serviceCallSite;
-        }
-
-        public virtual object Invoke(ServiceProvider provider)
-        {
-            object resolved;
-            lock (provider._resolvedServices)
-            {
-                if (!provider._resolvedServices.TryGetValue(Key, out resolved))
-                {
-                    resolved = ServiceCallSite.Invoke(provider);
-                    provider._resolvedServices.Add(Key, resolved);
-                }
-            }
-            return resolved;
         }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ServiceProviderService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ServiceProviderService.cs
@@ -19,10 +19,5 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             return this;
         }
-
-        public object Invoke(ServiceProvider provider)
-        {
-            return provider;
-        }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ServiceProviderService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ServiceProviderService.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
@@ -22,11 +21,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         }
 
         public object Invoke(ServiceProvider provider)
-        {
-            return provider;
-        }
-
-        public Expression Build(Expression provider)
         {
             return provider;
         }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ServiceScopeService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ServiceScopeService.cs
@@ -19,10 +19,5 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             return this;
         }
-
-        public object Invoke(ServiceProvider provider)
-        {
-            return new ServiceScopeFactory(provider);
-        }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ServiceScopeService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ServiceScopeService.cs
@@ -3,9 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Reflection;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
@@ -26,15 +23,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         public object Invoke(ServiceProvider provider)
         {
             return new ServiceScopeFactory(provider);
-        }
-
-        public Expression Build(Expression provider)
-        {
-            return Expression.New(
-                typeof(ServiceScopeFactory).GetTypeInfo()
-                    .DeclaredConstructors
-                    .Single(),
-                provider);
         }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/SingletonCallSite.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/SingletonCallSite.cs
@@ -3,18 +3,15 @@
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
-    internal class ConstantCallSite : IServiceCallSite
+    internal class SingletonCallSite : ScopedCallSite
     {
-        internal object DefaultValue { get; }
-
-        public ConstantCallSite(object defaultValue)
+        public SingletonCallSite(IService key, IServiceCallSite serviceCallSite) : base(key, serviceCallSite)
         {
-            DefaultValue = defaultValue;
         }
 
-        public object Invoke(ServiceProvider provider)
+        public override object Invoke(ServiceProvider provider)
         {
-            return DefaultValue;
+            return base.Invoke(provider._root);
         }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/SingletonCallSite.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/SingletonCallSite.cs
@@ -8,10 +8,5 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         public SingletonCallSite(IService key, IServiceCallSite serviceCallSite) : base(key, serviceCallSite)
         {
         }
-
-        public override object Invoke(ServiceProvider provider)
-        {
-            return base.Invoke(provider._root);
-        }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/TransientCallSite.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/TransientCallSite.cs
@@ -3,18 +3,18 @@
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
-    internal class ConstantCallSite : IServiceCallSite
+    internal class TransientCallSite : IServiceCallSite
     {
-        internal object DefaultValue { get; }
+        internal IServiceCallSite Service { get; }
 
-        public ConstantCallSite(object defaultValue)
+        public TransientCallSite(IServiceCallSite service)
         {
-            DefaultValue = defaultValue;
+            Service = service;
         }
 
         public object Invoke(ServiceProvider provider)
         {
-            return DefaultValue;
+            return provider.CaptureDisposable(Service.Invoke(provider));
         }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/TransientCallSite.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/TransientCallSite.cs
@@ -11,10 +11,5 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             Service = service;
         }
-
-        public object Invoke(ServiceProvider provider)
-        {
-            return provider.CaptureDisposable(Service.Invoke(provider));
-        }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
@@ -16,13 +16,13 @@ namespace Microsoft.Extensions.DependencyInjection
     /// <summary>
     /// The default IServiceProvider.
     /// </summary>
-    internal class ServiceProvider : IServiceProvider, IDisposable
+    class ServiceProvider : IServiceProvider, IDisposable
     {
-        public readonly ServiceProvider _root;
+        internal readonly ServiceProvider _root;
         private readonly ServiceTable _table;
         private bool _disposeCalled;
 
-        internal readonly Dictionary<IService, object> _resolvedServices = new Dictionary<IService, object>();
+        internal readonly Dictionary<object, object> _resolvedServices = new Dictionary<object, object>();
         private List<IDisposable> _transientDisposables;
 
         private static readonly Func<Type, ServiceProvider, Func<ServiceProvider, object>> _createServiceAccessor = CreateServiceAccessor;
@@ -87,14 +87,11 @@ namespace Microsoft.Extensions.DependencyInjection
                 {
                     Task.Run(() =>
                     {
-                        var providerExpression = Expression.Parameter(typeof(ServiceProvider), "provider");
+                        Expression<Func<ServiceProvider, object>> lambdaExpression =
+                            new CallSiteExpressionBuilder().Build(callSite);
 
-                        var lambdaExpression = Expression.Lambda<Func<ServiceProvider, object>>(
-                            callSite.Build(providerExpression),
-                            providerExpression);
-
-                        System.Console.WriteLine(serviceType+"=>"+GetDebugView(lambdaExpression));
-                        table.RealizedServices[serviceType] = lambdaExpression.Compile();
+                        var realizedService = lambdaExpression.Compile();
+                        table.RealizedServices[serviceType] = realizedService;
                     });
                 }
 
@@ -184,7 +181,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
         }
 
-        private object CaptureDisposable(object service)
+        public object CaptureDisposable(object service)
         {
             if (!object.ReferenceEquals(this, service))
             {
@@ -217,171 +214,6 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             return null;
-        }
-
-        private static MethodInfo CaptureDisposableMethodInfo = GetMethodInfo<Func<ServiceProvider, object, object>>((a, b) => a.CaptureDisposable(b));
-        private static MethodInfo TryGetValueMethodInfo = GetMethodInfo<Func<IDictionary<IService, object>, IService, object, bool>>((a, b, c) => a.TryGetValue(b, out c));
-        private static MethodInfo AddMethodInfo = GetMethodInfo<Action<IDictionary<IService, object>, IService, object>>((a, b, c) => a.Add(b, c));
-
-        private static MethodInfo MonitorEnterMethodInfo = GetMethodInfo<Action<object, bool>>((lockObj, lockTaken) => Monitor.Enter(lockObj, ref lockTaken));
-        private static MethodInfo MonitorExitMethodInfo = GetMethodInfo<Action<object>>(lockObj => Monitor.Exit(lockObj));
-
-        private static MethodInfo GetMethodInfo<T>(Expression<T> expr)
-        {
-            var mc = (MethodCallExpression)expr.Body;
-            return mc.Method;
-        }
-
-        private class EmptyIEnumerableCallSite : IServiceCallSite
-        {
-            private readonly object _serviceInstance;
-            private readonly Type _serviceType;
-
-            public EmptyIEnumerableCallSite(Type serviceType, object serviceInstance)
-            {
-                _serviceType = serviceType;
-                _serviceInstance = serviceInstance;
-            }
-
-            public object Invoke(ServiceProvider provider)
-            {
-                return _serviceInstance;
-            }
-
-            public Expression Build(Expression provider)
-            {
-                return Expression.Constant(_serviceInstance, _serviceType);
-            }
-        }
-
-        private class TransientCallSite : IServiceCallSite
-        {
-            private readonly IServiceCallSite _service;
-
-            public TransientCallSite(IServiceCallSite service)
-            {
-                _service = service;
-            }
-
-            public object Invoke(ServiceProvider provider)
-            {
-                return provider.CaptureDisposable(_service.Invoke(provider));
-            }
-
-            public Expression Build(Expression provider)
-            {
-                return Expression.Call(
-                    provider,
-                    CaptureDisposableMethodInfo,
-                    _service.Build(provider));
-            }
-        }
-
-        private class ScopedCallSite : IServiceCallSite
-        {
-            private readonly IService _key;
-            private readonly IServiceCallSite _serviceCallSite;
-
-            public ScopedCallSite(IService key, IServiceCallSite serviceCallSite)
-            {
-                _key = key;
-                _serviceCallSite = serviceCallSite;
-            }
-
-            public virtual object Invoke(ServiceProvider provider)
-            {
-                object resolved;
-                lock (provider._resolvedServices)
-                {
-                    if (!provider._resolvedServices.TryGetValue(_key, out resolved))
-                    {
-                        resolved = _serviceCallSite.Invoke(provider);
-                        provider._resolvedServices.Add(_key, resolved);
-                    }
-                }
-                return resolved;
-            }
-
-            public virtual Expression Build(Expression providerExpression)
-            {
-                var keyExpression = Expression.Constant(
-                    _key,
-                    typeof(IService));
-
-                var resolvedExpression = Expression.Variable(typeof(object), "resolved");
-                var resolvedServicesExpression = Expression.Field(
-                    providerExpression,
-                    "_resolvedServices");
-
-                var resolvedServicesVariable = Expression.Variable(typeof(IDictionary<IService, object>),
-                    "resolvedServices");
-                var resolvedServicesVariableAssignment = Expression.Assign(resolvedServicesVariable,
-                    resolvedServicesExpression);
-
-
-                var tryGetValueExpression = Expression.Call(
-                    resolvedServicesVariable,
-                    TryGetValueMethodInfo,
-                    keyExpression,
-                    resolvedExpression);
-
-                var assignExpression = Expression.Assign(
-                    resolvedExpression, _serviceCallSite.Build(providerExpression));
-
-                var addValueExpression = Expression.Call(
-                    resolvedServicesVariable,
-                    AddMethodInfo,
-                    keyExpression,
-                    resolvedExpression);
-
-                var blockExpression = Expression.Block(
-                    typeof(object),
-                    new[] {
-                        resolvedExpression
-                    },
-                    Expression.IfThen(
-                        Expression.Not(tryGetValueExpression),
-                        Expression.Block(assignExpression, addValueExpression)),
-                    resolvedExpression);
-
-                return Lock(blockExpression, resolvedServicesVariableAssignment, resolvedServicesVariable);
-            }
-
-            private static Expression Lock(Expression body, Expression before, ParameterExpression syncVariable)
-            {
-                // The C# compiler would copy the lock object to guard against mutation.
-                // We don't, since we know the lock object is readonly.
-                var lockWasTaken = Expression.Variable(typeof(bool), "lockWasTaken");
-
-                var monitorEnter = Expression.Call(MonitorEnterMethodInfo, syncVariable, lockWasTaken);
-                var monitorExit = Expression.Call(MonitorExitMethodInfo, syncVariable);
-
-                var tryBody = Expression.Block(monitorEnter, body);
-                var finallyBody = Expression.IfThen(lockWasTaken, monitorExit);
-
-                return Expression.Block(
-                    typeof(object),
-                    new[] { lockWasTaken, syncVariable },
-                    before,
-                    Expression.TryFinally(tryBody, finallyBody));
-            }
-        }
-
-        private class SingletonCallSite : ScopedCallSite
-        {
-            public SingletonCallSite(IService key, IServiceCallSite serviceCallSite) : base(key, serviceCallSite)
-            {
-            }
-
-            public override object Invoke(ServiceProvider provider)
-            {
-                return base.Invoke(provider._root);
-            }
-
-            public override Expression Build(Expression provider)
-            {
-                return base.Build(Expression.Field(provider, "_root"));
-            }
         }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
@@ -80,10 +80,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 {
                     Task.Run(() =>
                     {
-                        Expression<Func<ServiceProvider, object>> lambdaExpression =
-                            new CallSiteExpressionBuilder(_callSiteRuntimeResolver).Build(callSite);
-
-                        var realizedService = lambdaExpression.Compile();
+                        var realizedService = new CallSiteExpressionBuilder(_callSiteRuntimeResolver)
+                            .Build(callSite);
                         table.RealizedServices[serviceType] = realizedService;
                     });
                 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
@@ -25,7 +25,9 @@ namespace Microsoft.Extensions.DependencyInjection
         internal Dictionary<object, object> ResolvedServices { get; } = new Dictionary<object, object>();
 
         private static readonly Func<Type, ServiceProvider, Func<ServiceProvider, object>> _createServiceAccessor = CreateServiceAccessor;
-        private static CallSiteRuntimeResolver _callSiteRuntimeResolver = new CallSiteRuntimeResolver();
+
+        // CallSiteRuntimeResolver is stateless so can be shared between all instances
+        private static readonly CallSiteRuntimeResolver _callSiteRuntimeResolver = new CallSiteRuntimeResolver();
 
         public ServiceProvider(IEnumerable<ServiceDescriptor> serviceDescriptors)
         {
@@ -160,7 +162,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 }
 
                 // PERF: We've enumerating the dictionary so that we don't allocate to enumerate.
-                // .Values allocates a KeyCollection on the heap, enumerating the dictionary allocates
+                // .Values allocates a ValueCollection on the heap, enumerating the dictionary allocates
                 // a struct enumerator
                 foreach (var entry in ResolvedServices)
                 {

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     Task.Run(() =>
                     {
                         Expression<Func<ServiceProvider, object>> lambdaExpression =
-                            new CallSiteExpressionBuilder().Build(callSite);
+                            new CallSiteExpressionBuilder(_callSiteRuntimeResolver).Build(callSite);
 
                         var realizedService = lambdaExpression.Compile();
                         table.RealizedServices[serviceType] = realizedService;

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
@@ -46,9 +46,6 @@ namespace Microsoft.Extensions.DependencyInjection
             _table = parent._table;
         }
 
-        // Reusing _resolvedServices as an implementation detail of the lock
-        private object SyncObject => ResolvedServices;
-
         /// <summary>
         /// Gets the service object of the specified type.
         /// </summary>
@@ -140,15 +137,13 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public void Dispose()
         {
-            lock (SyncObject)
+            lock (ResolvedServices)
             {
                 if (_disposeCalled)
                 {
                     return;
                 }
-
                 _disposeCalled = true;
-
                 if (_transientDisposables != null)
                 {
                     foreach (var disposable in _transientDisposables)
@@ -178,7 +173,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 var disposable = service as IDisposable;
                 if (disposable != null)
                 {
-                    lock (SyncObject)
+                    lock (ResolvedServices)
                     {
                         if (_transientDisposables == null)
                         {

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
@@ -18,11 +18,11 @@ namespace Microsoft.Extensions.DependencyInjection
     /// </summary>
     class ServiceProvider : IServiceProvider, IDisposable
     {
-        internal readonly ServiceProvider _root;
+        private readonly ServiceProvider _root;
         private readonly ServiceTable _table;
         private bool _disposeCalled;
 
-        internal readonly Dictionary<object, object> _resolvedServices = new Dictionary<object, object>();
+        private readonly Dictionary<object, object> _resolvedServices = new Dictionary<object, object>();
         private List<IDisposable> _transientDisposables;
 
         private static readonly Func<Type, ServiceProvider, Func<ServiceProvider, object>> _createServiceAccessor = CreateServiceAccessor;
@@ -128,7 +128,6 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 callSiteChain.Remove(serviceType);
             }
-
         }
 
         internal IServiceCallSite GetResolveCallSite(IService service, ISet<Type> callSiteChain)

--- a/src/Microsoft.Extensions.DependencyInjection/project.json
+++ b/src/Microsoft.Extensions.DependencyInjection/project.json
@@ -23,13 +23,18 @@
     "Microsoft.Extensions.DependencyInjection.Abstractions": "1.1.0-*"
   },
   "frameworks": {
-    "netstandard1.1": {
+    "net451":  {
+      "frameworkAssemblies": {"System.Runtime": {} }
+    } ,
+    "netstandard1.5": {
       "dependencies": {
         "System.Collections": "4.0.11-*",
         "System.Collections.Concurrent": "4.0.12-*",
         "System.Runtime.Extensions": "4.1.0-*",
         "System.Threading": "4.0.11-*",
-        "System.Threading.Tasks": "4.0.11-*"
+        "System.Console": "4.0.0-*",
+        "System.Threading.Tasks": "4.0.11-*",
+        "System.Reflection": "4.1.0-*"
       }
     }
   }

--- a/src/Microsoft.Extensions.DependencyInjection/project.json
+++ b/src/Microsoft.Extensions.DependencyInjection/project.json
@@ -23,18 +23,13 @@
     "Microsoft.Extensions.DependencyInjection.Abstractions": "1.1.0-*"
   },
   "frameworks": {
-    "net451":  {
-      "frameworkAssemblies": {"System.Runtime": {} }
-    } ,
-    "netstandard1.5": {
+    "netstandard1.1": {
       "dependencies": {
         "System.Collections": "4.0.11-*",
         "System.Collections.Concurrent": "4.0.12-*",
         "System.Runtime.Extensions": "4.1.0-*",
         "System.Threading": "4.0.11-*",
-        "System.Console": "4.0.0-*",
-        "System.Threading.Tasks": "4.0.11-*",
-        "System.Reflection": "4.1.0-*"
+        "System.Threading.Tasks": "4.0.11-*"
       }
     }
   }

--- a/test/Microsoft.Extensions.DependencyInjection.Tests/CallSiteTests.cs
+++ b/test/Microsoft.Extensions.DependencyInjection.Tests/CallSiteTests.cs
@@ -168,13 +168,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 
         private static Func<ServiceProvider, object> CompileCallSite(IServiceCallSite callSite)
         {
-            var providerExpression = Expression.Parameter(typeof(ServiceProvider), "provider");
-
-            var lambdaExpression = Expression.Lambda<Func<ServiceProvider, object>>(
-                callSite.Build(providerExpression),
-                providerExpression);
-
-            return lambdaExpression.Compile();
+            return new CallSiteExpressionBuilder().Build(callSite).Compile();
         }
     }
 }

--- a/test/Microsoft.Extensions.DependencyInjection.Tests/CallSiteTests.cs
+++ b/test/Microsoft.Extensions.DependencyInjection.Tests/CallSiteTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             var compiledCallSite = CompileCallSite(callSite);
             var compiledCollectionCallSite = CompileCallSite(collectionCallSite);
 
-            var service1 = callSite.Invoke(provider);
+            var service1 = Invoke(callSite, provider);
             var service2 = compiledCallSite(provider);
             var serviceEnumerator = ((IEnumerable)compiledCollectionCallSite(provider)).GetEnumerator();
 
@@ -116,7 +116,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             var serviceC = (ServiceC)compiledCallSite(provider);
 
             Assert.NotNull(serviceC.ServiceB.ServiceA);
-            Assert.Equal(serviceC, callSite.Invoke(provider));
+            Assert.Equal(serviceC, Invoke(callSite, provider));
         }
 
         [Fact]
@@ -164,6 +164,11 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             }
 
             public ServiceB ServiceB { get; set; }
+        }
+
+        private static object Invoke(IServiceCallSite callSite, ServiceProvider provider)
+        {
+            return new CallSiteRuntimeResolver().Resolve(callSite, provider);
         }
 
         private static Func<ServiceProvider, object> CompileCallSite(IServiceCallSite callSite)

--- a/test/Microsoft.Extensions.DependencyInjection.Tests/CallSiteTests.cs
+++ b/test/Microsoft.Extensions.DependencyInjection.Tests/CallSiteTests.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 {
     public class CallSiteTests
     {
+        private static readonly CallSiteRuntimeResolver CallSiteRuntimeResolver = new CallSiteRuntimeResolver();
+
         public static IEnumerable<object[]> TestServiceDescriptors(ServiceLifetime lifetime)
         {
             Func<object, object, bool> compare;
@@ -168,12 +170,12 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 
         private static object Invoke(IServiceCallSite callSite, ServiceProvider provider)
         {
-            return new CallSiteRuntimeResolver().Resolve(callSite, provider);
+            return CallSiteRuntimeResolver.Resolve(callSite, provider);
         }
 
         private static Func<ServiceProvider, object> CompileCallSite(IServiceCallSite callSite)
         {
-            return new CallSiteExpressionBuilder().Build(callSite).Compile();
+            return new CallSiteExpressionBuilder(CallSiteRuntimeResolver).Build(callSite).Compile();
         }
     }
 }

--- a/test/Microsoft.Extensions.DependencyInjection.Tests/CallSiteTests.cs
+++ b/test/Microsoft.Extensions.DependencyInjection.Tests/CallSiteTests.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 
         private static Func<ServiceProvider, object> CompileCallSite(IServiceCallSite callSite)
         {
-            return new CallSiteExpressionBuilder(CallSiteRuntimeResolver).Build(callSite).Compile();
+            return new CallSiteExpressionBuilder(CallSiteRuntimeResolver).Build(callSite);
         }
     }
 }

--- a/test/Microsoft.Extensions.DependencyInjection.Tests/ServiceLookup/ServiceTest.cs
+++ b/test/Microsoft.Extensions.DependencyInjection.Tests/ServiceLookup/ServiceTest.cs
@@ -402,7 +402,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         private static IEnumerable<Type> GetParameters(ConstructorCallSite constructorCallSite) =>
             constructorCallSite
-                .Constructor
+                .ConstructorInfo
                 .GetParameters()
                 .Select(p => p.ParameterType);
 


### PR DESCRIPTION
Fixes: https://github.com/aspnet/DependencyInjection/issues/425 by caching private field access into local variables.
Also optimizes amount of `Monitor.Enter/Exit` and `try/catch` we do for scope services.
## Test case:

IdentitySample.Mvc project
Run `net451` and request `/` multiple times to force all services to compile.
## Before

**234 MB** allocation from `Microsoft.Extensions.DependencyInjection.ServiceProvider+<>c__DisplayClass17_0.<RealizeService>b__1()`, **223 MB** because of CAS checks.
And **2700ms** total compilation time.
![http://i.imgur.com/mm7VunG.png](http://i.imgur.com/mm7VunG.png)
## After

**9.8 MB** allocation from `Microsoft.Extensions.DependencyInjection.ServiceProvider+<>c__DisplayClass17_0.<RealizeService>b__1()`, **4.3 MB** because of CAS checks.
And **400ms** total compilation time.

![http://i.imgur.com/pJkQSj5.png](http://i.imgur.com/pJkQSj5.png)
## After + No trees for singletons

**2.7 MB** allocation from `Microsoft.Extensions.DependencyInjection.ServiceProvider+<>c__DisplayClass17_0.<RealizeService>b__1()`, **1.8 MB** because of CAS checks.
And **122ms** total compilation time.

![http://i.imgur.com/xIep1KC.png](http://i.imgur.com/xIep1KC.png)
## After + No trees for singletons + Short circuit singletons

https://github.com/aspnet/DependencyInjection/pull/429/files#diff-800d14c6aa47e810955d46f860d9502cR52

**1.6 MB** allocation from `Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteExpressionBuilder.Build(IServiceCallSite)`, **1.2 MB** because of CAS checks.
And **89ms** total compilation time.

![http://i.imgur.com/r3CeDJP.png](http://i.imgur.com/r3CeDJP.png)

@halter73 @davidfowl 
