### PR TITLE
Added ServiceProviderOptions type that flows to the container

### DIFF
--- a/src/Microsoft.Extensions.DependencyInjection/DefaultServiceProviderFactory.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/DefaultServiceProviderFactory.cs
@@ -4,6 +4,23 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public class DefaultServiceProviderFactory : IServiceProviderFactory<IServiceCollection>
     {
+        private readonly ServiceProviderOptions _options = ServiceProviderOptions.Default;
+
+        public DefaultServiceProviderFactory()
+        {
+
+        }
+
+        public DefaultServiceProviderFactory(ServiceProviderOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            _options = options;
+        }
+
         public IServiceCollection CreateBuilder(IServiceCollection services)
         {
             return services;
@@ -11,7 +28,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public IServiceProvider CreateServiceProvider(IServiceCollection containerBuilder)
         {
-            return containerBuilder.BuildServiceProvider();
+            return containerBuilder.BuildServiceProvider(_options);
         }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/DefaultServiceProviderFactory.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/DefaultServiceProviderFactory.cs
@@ -4,9 +4,9 @@ namespace Microsoft.Extensions.DependencyInjection
 {
     public class DefaultServiceProviderFactory : IServiceProviderFactory<IServiceCollection>
     {
-        private readonly ServiceProviderOptions _options = ServiceProviderOptions.Default;
+        private readonly ServiceProviderOptions _options;
 
-        public DefaultServiceProviderFactory()
+        public DefaultServiceProviderFactory() : this(ServiceProviderOptions.Default)
         {
 
         }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceCollectionContainerBuilderExtensions.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceCollectionContainerBuilderExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public static IServiceProvider BuildServiceProvider(this IServiceCollection services)
         {
-            return BuildServiceProvider(services, validateScopes: false);
+            return BuildServiceProvider(services, ServiceProviderOptions.Default);
         }
 
         /// <summary>
@@ -29,7 +29,31 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <returns>The<see cref="IServiceProvider"/>.</returns>
         public static IServiceProvider BuildServiceProvider(this IServiceCollection services, bool validateScopes)
         {
-            return new ServiceProvider(services, validateScopes);
+            return services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = validateScopes });
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IServiceProvider"/> containing services from the provided <see cref="IServiceCollection"/>
+        /// optionaly enabling scope validation.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> containing service descriptors.</param>
+        /// <param name="options">
+        /// Configures various service provider behaviors.
+        /// </param>
+        /// <returns>The<see cref="IServiceProvider"/>.</returns>
+        public static IServiceProvider BuildServiceProvider(this IServiceCollection services, ServiceProviderOptions options)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            return new ServiceProvider(services, options);
         }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Extensions.DependencyInjection
     {
         private readonly CallSiteValidator _callSiteValidator;
         private readonly ServiceTable _table;
+        private readonly ServiceProviderOptions _options;
         private bool _disposeCalled;
         private List<IDisposable> _transientDisposables;
 
@@ -30,15 +31,16 @@ namespace Microsoft.Extensions.DependencyInjection
         // CallSiteRuntimeResolver is stateless so can be shared between all instances
         private static readonly CallSiteRuntimeResolver _callSiteRuntimeResolver = new CallSiteRuntimeResolver();
 
-        public ServiceProvider(IEnumerable<ServiceDescriptor> serviceDescriptors, bool validateScopes)
+        public ServiceProvider(IEnumerable<ServiceDescriptor> serviceDescriptors, ServiceProviderOptions options)
         {
             Root = this;
 
-            if (validateScopes)
+            if (options.ValidateScopes)
             {
                 _callSiteValidator = new CallSiteValidator();
             }
 
+            _options = options;
             _table = new ServiceTable(serviceDescriptors);
 
             _table.Add(typeof(IServiceProvider), new ServiceProviderService());

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceProviderOptions.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceProviderOptions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Options for configuring various behaviors of the default <see cref="IServiceProvider"/> implementation.
+    /// </summary>
+    public class ServiceProviderOptions
+    {
+        // Avoid allocating objects in the default case
+        internal static readonly ServiceProviderOptions Default = new ServiceProviderOptions();
+
+        /// <summary>
+        /// <c>true</c> to perform check verifying that scoped services never gets resolved from root provider; otherwise <c>false</c>.
+        /// </summary>
+        public bool ValidateScopes { get; set; }
+    }
+}

--- a/test/Microsoft.Extensions.DependencyInjection.Tests/CallSiteTests.cs
+++ b/test/Microsoft.Extensions.DependencyInjection.Tests/CallSiteTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         public void BuiltExpressionWillReturnResolvedServiceWhenAppropriate(
             ServiceDescriptor[] descriptors, Type serviceType, Func<object, object, bool> compare)
         {
-            var provider = new ServiceProvider(descriptors, validateScopes: true);
+            var provider = new ServiceProvider(descriptors, new ServiceProviderOptions { ValidateScopes = true });
 
             var callSite = provider.GetServiceCallSite(serviceType, new HashSet<Type>());
             var collectionCallSite = provider.GetServiceCallSite(typeof(IEnumerable<>).MakeGenericType(serviceType), new HashSet<Type>());
@@ -111,7 +111,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             descriptors.AddScoped<ServiceB>();
             descriptors.AddScoped<ServiceC>();
 
-            var provider = new ServiceProvider(descriptors, validateScopes: true);
+            var provider = new ServiceProvider(descriptors, new ServiceProviderOptions { ValidateScopes = true });
             var callSite = provider.GetServiceCallSite(typeof(ServiceC), new HashSet<Type>());
             var compiledCallSite = CompileCallSite(callSite);
 
@@ -129,7 +129,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             descriptors.AddTransient<ClassWithThrowingCtor>();
             descriptors.AddTransient<IFakeService, FakeService>();
 
-            var provider = new ServiceProvider(descriptors, validateScopes: true);
+            var provider = new ServiceProvider(descriptors, new ServiceProviderOptions { ValidateScopes = true });
 
             var callSite1 = provider.GetServiceCallSite(typeof(ClassWithThrowingEmptyCtor), new HashSet<Type>());
             var compiledCallSite1 = CompileCallSite(callSite1);

--- a/test/Microsoft.Extensions.DependencyInjection.Tests/ServiceLookup/ServiceTest.cs
+++ b/test/Microsoft.Extensions.DependencyInjection.Tests/ServiceLookup/ServiceTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 "Ensure the type is concrete and services are registered for all parameters of a public constructor.";
             var descriptor = new ServiceDescriptor(type, type, ServiceLifetime.Transient);
             var service = new Service(descriptor);
-            var serviceProvider = new ServiceProvider(new[] { descriptor }, validateScopes: true);
+            var serviceProvider = new ServiceProvider(new[] { descriptor }, new ServiceProviderOptions { ValidateScopes = true });
 
             // Act and Assert
             var ex = Assert.Throws<InvalidOperationException>(() => service.CreateCallSite(serviceProvider, new HashSet<Type>()));
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             // Arrange
             var descriptor = new ServiceDescriptor(type, type, ServiceLifetime.Transient);
             var service = new Service(descriptor);
-            var serviceProvider = new ServiceProvider(new[] { descriptor }, validateScopes: true);
+            var serviceProvider = new ServiceProvider(new[] { descriptor }, new ServiceProviderOptions { ValidateScopes = true });
 
             // Act
             var callSite = service.CreateCallSite(serviceProvider, new HashSet<Type>());
@@ -99,7 +99,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var type = typeof(TypeWithParameterizedAndNullaryConstructor);
             var descriptor = new ServiceDescriptor(type, type, ServiceLifetime.Transient);
             var service = new Service(descriptor);
-            var serviceProvider = new ServiceProvider(new[] { descriptor }, validateScopes: true);
+            var serviceProvider = new ServiceProvider(new[] { descriptor }, new ServiceProviderOptions { ValidateScopes = true });
 
             // Act
             var callSite = service.CreateCallSite(serviceProvider, new HashSet<Type>());


### PR DESCRIPTION
- We'll need to add more options soon
(like disabling transient disposable capture), this change adds an overload to
BuildServiceProvider(), adds a ctor to the DefaultServiceProviderFactory and adds
ctor to ServiceProvider that take the ServiceProviderOptions.

/cc @halter73 @pakrym 