### PR TITLE
Removed duplicate call site chain search

### DIFF
--- a/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
@@ -103,12 +103,11 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             try
             {
-                if (callSiteChain.Contains(serviceType))
+                // ISet.Add returns false if serviceType already present in call Site Chain
+                if (!callSiteChain.Add(serviceType))
                 {
                     throw new InvalidOperationException(Resources.FormatCircularDependencyException(serviceType));
                 }
-
-                callSiteChain.Add(serviceType);
 
                 ServiceEntry entry;
                 if (_table.TryGetEntry(serviceType, out entry))


### PR DESCRIPTION
Minor PERF update: Since the call site chain is an `ISet`, the `Add` method return value makes the call to the `Contains` method redundant.

Effectively this means, that the call site chain is only searched once, instead of twice.

The performance benefit from this is probably very small. I stumbled over it accidentally while debugging the default `ServiceProvider`. But it can't hurt to try to optimize things.