### PR TITLE
Better codegen

### DIFF
--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteRuntimeResolver.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteRuntimeResolver.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         protected override object VisitTransient(TransientCallSite transientCallSite, ServiceProvider provider)
         {
             return provider.CaptureDisposable(
-                VisitCallSite(transientCallSite.Service, provider));
+                VisitCallSite(transientCallSite.ServiceCallSite, provider));
         }
 
         protected override object VisitConstructor(ConstructorCallSite constructorCallSite, ServiceProvider provider)

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteValidator.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteValidator.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         protected override Type VisitTransient(TransientCallSite transientCallSite, CallSiteValidatorState state)
         {
-            return VisitCallSite(transientCallSite.Service, state);
+            return VisitCallSite(transientCallSite.ServiceCallSite, state);
         }
 
         protected override Type VisitConstructor(ConstructorCallSite constructorCallSite, CallSiteValidatorState state)

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ClosedIEnumerableService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ClosedIEnumerableService.cs
@@ -3,13 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal class ClosedIEnumerableService : IService
     {
-        private readonly Type _itemType;
         private readonly ServiceEntry _serviceEntry;
 
         public ClosedIEnumerableService(Type itemType, ServiceEntry entry)
@@ -39,7 +37,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 list.Add(provider.GetResolveCallSite(service, callSiteChain));
                 service = service.Next;
             }
-            return new ClosedIEnumerableCallSite(_itemType, list.ToArray());
+            return new ClosedIEnumerableCallSite(ServiceType, list.ToArray());
         }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ClosedIEnumerableService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ClosedIEnumerableService.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         public ClosedIEnumerableService(Type itemType, ServiceEntry entry)
         {
-            _itemType = itemType;
+            ServiceType = itemType;
             _serviceEntry = entry;
-            ImplementationType = _itemType.MakeArrayType();
+            ImplementationType = itemType.MakeArrayType();
         }
 
         public IService Next { get; set; }
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             get { return ServiceLifetime.Transient; }
         }
 
-        public Type ServiceType => _itemType;
+        public Type ServiceType { get; }
 
         public Type ImplementationType { get; }
 

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ClosedIEnumerableService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ClosedIEnumerableService.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             _itemType = itemType;
             _serviceEntry = entry;
+            ImplementationType = _itemType.MakeArrayType();
         }
 
         public IService Next { get; set; }
@@ -26,6 +27,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         }
 
         public Type ServiceType => _itemType;
+
+        public Type ImplementationType { get; }
 
         public IServiceCallSite CreateCallSite(ServiceProvider provider, ISet<Type> callSiteChain)
         {

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/FactoryService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/FactoryService.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         public Type ServiceType => Descriptor.ServiceType;
 
-        public Type ImplementationType => Descriptor.ImplementationType;
+        public Type ImplementationType => null;
 
         public IServiceCallSite CreateCallSite(ServiceProvider provider, ISet<Type> callSiteChain)
         {

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/FactoryService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/FactoryService.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         public Type ServiceType => Descriptor.ServiceType;
 
+        public Type ImplementationType => Descriptor.ImplementationType;
+
         public IServiceCallSite CreateCallSite(ServiceProvider provider, ISet<Type> callSiteChain)
         {
             return this;

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/IService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/IService.cs
@@ -15,5 +15,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         IServiceCallSite CreateCallSite(ServiceProvider provider, ISet<Type> callSiteChain);
 
         Type ServiceType { get; }
+
+        Type ImplementationType { get; }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/InstanceService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/InstanceService.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         public InstanceService(ServiceDescriptor descriptor)
         {
             Descriptor = descriptor;
-            ImplementationType = descriptor.ImplementationInstance?.GetType();
+            ImplementationType = descriptor.ImplementationInstance.GetType();
         }
 
         public IService Next { get; set; }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/InstanceService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/InstanceService.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         public InstanceService(ServiceDescriptor descriptor)
         {
             Descriptor = descriptor;
+            ImplementationType = descriptor.ImplementationInstance?.GetType();
         }
 
         public IService Next { get; set; }
@@ -27,7 +28,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         public Type ServiceType => Descriptor.ServiceType;
 
-        public Type ImplementationType => Descriptor.ImplementationType;
+        public Type ImplementationType { get; }
 
         public IServiceCallSite CreateCallSite(ServiceProvider provider, ISet<Type> callSiteChain)
         {

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/InstanceService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/InstanceService.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         public Type ServiceType => Descriptor.ServiceType;
 
+        public Type ImplementationType => Descriptor.ImplementationType;
+
         public IServiceCallSite CreateCallSite(ServiceProvider provider, ISet<Type> callSiteChain)
         {
             return this;

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/Service.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/Service.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             get { return _descriptor.Lifetime; }
         }
 
+        public Type ImplementationType => _descriptor.ImplementationType;
+
         public IServiceCallSite CreateCallSite(ServiceProvider provider, ISet<Type> callSiteChain)
         {
             var constructors = _descriptor.ImplementationType.GetTypeInfo()

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ServiceProviderService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ServiceProviderService.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         public Type ServiceType => typeof(IServiceProvider);
 
+        public Type ImplementationType => typeof(ServiceProvider);
+
         public IServiceCallSite CreateCallSite(ServiceProvider provider, ISet<Type> callSiteChain)
         {
             return this;

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ServiceScopeService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ServiceScopeService.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         public Type ServiceType => typeof(IServiceScopeFactory);
 
+        public Type ImplementationType => typeof(ServiceScopeFactory);
+
         public IServiceCallSite CreateCallSite(ServiceProvider provider, ISet<Type> callSiteChain)
         {
             return this;

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/TransientCallSite.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/TransientCallSite.cs
@@ -5,11 +5,13 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal class TransientCallSite : IServiceCallSite
     {
-        internal IServiceCallSite Service { get; }
+        internal IService Service { get; }
+        internal IServiceCallSite ServiceCallSite { get; }
 
-        public TransientCallSite(IServiceCallSite service)
+        public TransientCallSite(IService key, IServiceCallSite serviceCallSite)
         {
-            Service = service;
+            Service = key;
+            ServiceCallSite = serviceCallSite;
         }
     }
 }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
@@ -28,6 +28,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static readonly Func<Type, ServiceProvider, Func<ServiceProvider, object>> _createServiceAccessor = CreateServiceAccessor;
 
+        // For testing only
+        internal Action<object> _captureDisposableCallback;
+
         // CallSiteRuntimeResolver is stateless so can be shared between all instances
         private static readonly CallSiteRuntimeResolver _callSiteRuntimeResolver = new CallSiteRuntimeResolver();
 
@@ -186,8 +189,10 @@ namespace Microsoft.Extensions.DependencyInjection
             }
         }
 
-        internal virtual object CaptureDisposable(object service)
+        internal object CaptureDisposable(object service)
         {
+            _captureDisposableCallback?.Invoke(service);
+
             if (!object.ReferenceEquals(this, service))
             {
                 var disposable = service as IDisposable;

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             if (service.Lifetime == ServiceLifetime.Transient)
             {
-                return new TransientCallSite(serviceCallSite);
+                return new TransientCallSite(service, serviceCallSite);
             }
             else if (service.Lifetime == ServiceLifetime.Scoped)
             {
@@ -186,7 +186,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
         }
 
-        internal object CaptureDisposable(object service)
+        internal virtual object CaptureDisposable(object service)
         {
             if (!object.ReferenceEquals(this, service))
             {


### PR DESCRIPTION
- Elide calls to CaptureDisposable for transient services when the
implementation type isn't disposable
- Elide calls to Convert when the type is already assignable from
the target type

Examples:

```C#
private class ServiceD
{
    public ServiceD(IEnumerable<ServiceA> services)
    {

    }
}

private class ServiceA
{
}

private class ServiceB
{
    public ServiceB(ServiceA serviceA)
    {
        ServiceA = serviceA;
    }

    public ServiceA ServiceA { get; set; }
}

private class ServiceC
{
    public ServiceC(ServiceB serviceB)
    {
        ServiceB = serviceB;
    }

    public ServiceB ServiceB { get; set; }
}
```

Scenario 1:

```C#
GetService<ServiceD>();
```

Before

```C#
public static object GenerateCode(ServiceProvider serviceProvider)
{
	Program.ServiceA[] expr_06 = new Program.ServiceA[1];
	int arg_1A_1 = 0;
	object obj = new Program.ServiceA();
	expr_06[arg_1A_1] = (Program.ServiceA)serviceProvider.CaptureDisposable(obj);
	object obj2 = expr_06;
	object obj3 = new Program.ServiceD((IEnumerable<Program.ServiceA>)serviceProvider.CaptureDisposable(obj2));
	return serviceProvider.CaptureDisposable(obj3);
}
```

After

```C#
public static object GenerateCode(ServiceProvider serviceProvider)
{
	return new Program.ServiceD(new Program.ServiceA[]
	{
		new Program.ServiceA()
	});
}
```

Scenario 2:

```C#
GetService<ServiceC>()
```

Before

```C#
public static object GenerateCode(ServiceProvider serviceProvider)
{
	object obj = new Program.ServiceA();
	object obj2 = new Program.ServiceB((Program.ServiceA)serviceProvider.CaptureDisposable(obj));
	object obj3 = new Program.ServiceC((Program.ServiceB)serviceProvider.CaptureDisposable(obj2));
	return serviceProvider.CaptureDisposable(obj3);
}
```

After

```C#
public static object GenerateCode(ServiceProvider serviceProvider)
{
	return new Program.ServiceC(new Program.ServiceB(new Program.ServiceA()));
}

```
