### PR TITLE
Added scope validation benchmark

### DIFF
--- a/test/Microsoft.Extensions.DependencyInjection.Performance/GetServiceBenchmark.cs
+++ b/test/Microsoft.Extensions.DependencyInjection.Performance/GetServiceBenchmark.cs
@@ -7,7 +7,7 @@ using BenchmarkDotNet.Attributes;
 namespace Microsoft.Extensions.DependencyInjection.Performance
 {
     [Config(typeof(CoreConfig))]
-    public class ResolvePerformance
+    public class GetServiceBenchmark
     {
         private const int OperationsPerInvoke = 50000;
 

--- a/test/Microsoft.Extensions.DependencyInjection.Performance/GetServiceBenchmark.cs
+++ b/test/Microsoft.Extensions.DependencyInjection.Performance/GetServiceBenchmark.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;

--- a/test/Microsoft.Extensions.DependencyInjection.Performance/Program.cs
+++ b/test/Microsoft.Extensions.DependencyInjection.Performance/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Reflection;
 using BenchmarkDotNet.Running;
 

--- a/test/Microsoft.Extensions.DependencyInjection.Performance/ScopeValidationBenchmark.cs
+++ b/test/Microsoft.Extensions.DependencyInjection.Performance/ScopeValidationBenchmark.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+
+namespace Microsoft.Extensions.DependencyInjection.Performance
+{
+    [Config(typeof(CoreConfig))]
+    public class ScopeValidationBenchmark
+    {
+        private const int OperationsPerInvoke = 50000;
+
+        private IServiceProvider _transientSp;
+        private IServiceProvider _transientSpScopeValidation;
+        private IServiceScope _scopedSpScopeValidation;
+        private IServiceProvider _singletonSpScopeValidation;
+
+        [Setup]
+        public void Setup()
+        {
+            var services = new ServiceCollection();
+            services.AddTransient<A>();
+            services.AddTransient<B>();
+            services.AddTransient<C>();
+            _transientSp = services.BuildServiceProvider();
+
+            services = new ServiceCollection();
+            services.AddTransient<A>();
+            services.AddTransient<B>();
+            services.AddTransient<C>();
+            _transientSpScopeValidation = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+
+
+            services = new ServiceCollection();
+            services.AddScoped<A>();
+            services.AddScoped<B>();
+            services.AddScoped<C>();
+            _scopedSpScopeValidation = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true }).CreateScope();
+
+
+            services = new ServiceCollection();
+            services.AddSingleton<A>();
+            services.AddSingleton<B>();
+            services.AddSingleton<C>();
+            _singletonSpScopeValidation = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
+        }
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = OperationsPerInvoke)]
+        public void Transient()
+        {
+            for (int i = 0; i < OperationsPerInvoke; i++)
+            {
+                var temp = _transientSp.GetService<A>();
+                temp.Foo();
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+        public void TransientWithScopeValidation()
+        {
+            for (int i = 0; i < OperationsPerInvoke; i++)
+            {
+                var temp = _transientSpScopeValidation.GetService<A>();
+                temp.Foo();
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+        public void ScopedWithScopeValidation()
+        {
+            for (int i = 0; i < OperationsPerInvoke; i++)
+            {
+                var temp = _scopedSpScopeValidation.ServiceProvider.GetService<A>();
+                temp.Foo();
+            }
+        }
+
+        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
+        public void SingletonWithScopeValidation()
+        {
+            for (int i = 0; i < OperationsPerInvoke; i++)
+            {
+                var temp = _singletonSpScopeValidation.GetService<A>();
+                temp.Foo();
+            }
+        }
+
+        private class A
+        {
+            public A(B b)
+            {
+
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public void Foo()
+            {
+
+            }
+        }
+
+        private class B
+        {
+            public B(C c)
+            {
+
+            }
+        }
+
+        private class C
+        {
+
+        }
+    }
+}

--- a/test/Microsoft.Extensions.DependencyInjection.Performance/ScopeValidationBenchmark.cs
+++ b/test/Microsoft.Extensions.DependencyInjection.Performance/ScopeValidationBenchmark.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;

--- a/test/Microsoft.Extensions.DependencyInjection.Performance/ScopeValidationBenchmark.cs
+++ b/test/Microsoft.Extensions.DependencyInjection.Performance/ScopeValidationBenchmark.cs
@@ -13,8 +13,6 @@ namespace Microsoft.Extensions.DependencyInjection.Performance
 
         private IServiceProvider _transientSp;
         private IServiceProvider _transientSpScopeValidation;
-        private IServiceScope _scopedSpScopeValidation;
-        private IServiceProvider _singletonSpScopeValidation;
 
         [Setup]
         public void Setup()
@@ -30,20 +28,6 @@ namespace Microsoft.Extensions.DependencyInjection.Performance
             services.AddTransient<B>();
             services.AddTransient<C>();
             _transientSpScopeValidation = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
-
-
-            services = new ServiceCollection();
-            services.AddScoped<A>();
-            services.AddScoped<B>();
-            services.AddScoped<C>();
-            _scopedSpScopeValidation = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true }).CreateScope();
-
-
-            services = new ServiceCollection();
-            services.AddSingleton<A>();
-            services.AddSingleton<B>();
-            services.AddSingleton<C>();
-            _singletonSpScopeValidation = services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
         }
 
         [Benchmark(Baseline = true, OperationsPerInvoke = OperationsPerInvoke)]
@@ -62,26 +46,6 @@ namespace Microsoft.Extensions.DependencyInjection.Performance
             for (int i = 0; i < OperationsPerInvoke; i++)
             {
                 var temp = _transientSpScopeValidation.GetService<A>();
-                temp.Foo();
-            }
-        }
-
-        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-        public void ScopedWithScopeValidation()
-        {
-            for (int i = 0; i < OperationsPerInvoke; i++)
-            {
-                var temp = _scopedSpScopeValidation.ServiceProvider.GetService<A>();
-                temp.Foo();
-            }
-        }
-
-        [Benchmark(OperationsPerInvoke = OperationsPerInvoke)]
-        public void SingletonWithScopeValidation()
-        {
-            for (int i = 0; i < OperationsPerInvoke; i++)
-            {
-                var temp = _singletonSpScopeValidation.GetService<A>();
                 temp.Foo();
             }
         }


### PR DESCRIPTION
- Renamed benchmarks to *Benchmark

```
                       Method |        Mean |    StdErr |     StdDev |        Op/s | Scaled | Scaled-StdDev |  Gen 0 | Allocated |
----------------------------- |------------ |---------- |----------- |------------ |------- |-------------- |------- |---------- |
                    Transient |  43.5473 ns | 0.4130 ns |  2.2620 ns | 22963524.25 |   1.00 |          0.00 | 0.0095 |      24 B |
 TransientWithScopeValidation |  68.7545 ns | 1.3960 ns |  7.6460 ns | 14544498.22 |   1.58 |          0.19 | 0.0076 |      24 B |
    ScopedWithScopeValidation | 105.1968 ns | 1.9990 ns | 10.9491 ns |   9505991.5 |   2.42 |          0.28 |      - |       0 B |
 SingletonWithScopeValidation | 136.7783 ns | 2.0167 ns | 11.0459 ns |  7311100.08 |   3.15 |          0.29 |      - |       0 B |
```