### PR TITLE
Different singleton registrations resolve to same instance

### DIFF
--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteRuntimeResolver.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/CallSiteRuntimeResolver.cs
@@ -48,8 +48,17 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             {
                 if (!provider.ResolvedServices.TryGetValue(scopedCallSite.Key, out resolved))
                 {
-                    resolved = VisitCallSite(scopedCallSite.ServiceCallSite, provider);
-                    provider.CaptureDisposable(resolved);
+                    if (scopedCallSite.Key.ImplementationType == null ||
+                        !provider.ResolvedSingletonServices.TryGetValue(scopedCallSite.Key.ImplementationType, out resolved))
+                    {
+                        resolved = VisitCallSite(scopedCallSite.ServiceCallSite, provider);
+                        provider.CaptureDisposable(resolved);
+
+                        if (scopedCallSite.Key.ImplementationType != null)
+                        {
+                            provider.ResolvedSingletonServices.Add(scopedCallSite.Key.ImplementationType, resolved);
+                        }
+                    }
                     provider.ResolvedServices.Add(scopedCallSite.Key, resolved);
                 }
             }

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         internal ServiceProvider Root { get; }
         internal Dictionary<object, object> ResolvedServices { get; } = new Dictionary<object, object>();
+        internal Dictionary<Type, object> ResolvedSingletonServices { get; } = new Dictionary<Type, object>();
 
         private static readonly Func<Type, ServiceProvider, Func<ServiceProvider, object>> _createServiceAccessor = CreateServiceAccessor;
 


### PR DESCRIPTION
- Singleton uses same instance when registered with different service types
- Scoped instances are same within a scope but are different across scopes
- Singleton instances are disposed exactly once

https://github.com/aspnet/DependencyInjection/issues/360