### PR TITLE
Make ServiceProvider public

### DIFF
--- a/src/Microsoft.Extensions.DependencyInjection/ServiceCollectionContainerBuilderExtensions.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceCollectionContainerBuilderExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The <see cref="IServiceCollection"/> containing service descriptors.</param>
         /// <returns>The<see cref="IServiceProvider"/>.</returns>
 
-        public static IServiceProvider BuildServiceProvider(this IServiceCollection services)
+        public static ServiceProvider BuildServiceProvider(this IServiceCollection services)
         {
             return BuildServiceProvider(services, ServiceProviderOptions.Default);
         }
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <c>true</c> to perform check verifying that scoped services never gets resolved from root provider; otherwise <c>false</c>.
         /// </param>
         /// <returns>The<see cref="IServiceProvider"/>.</returns>
-        public static IServiceProvider BuildServiceProvider(this IServiceCollection services, bool validateScopes)
+        public static ServiceProvider BuildServiceProvider(this IServiceCollection services, bool validateScopes)
         {
             return services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = validateScopes });
         }
@@ -41,7 +41,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Configures various service provider behaviors.
         /// </param>
         /// <returns>The<see cref="IServiceProvider"/>.</returns>
-        public static IServiceProvider BuildServiceProvider(this IServiceCollection services, ServiceProviderOptions options)
+        public static ServiceProvider BuildServiceProvider(this IServiceCollection services, ServiceProviderOptions options)
         {
             if (services == null)
             {

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceProvider.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,7 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection
     /// <summary>
     /// The default IServiceProvider.
     /// </summary>
-    internal class ServiceProvider : IServiceProvider, IDisposable
+    public sealed class ServiceProvider : IServiceProvider, IDisposable
     {
         private readonly CallSiteValidator _callSiteValidator;
         private readonly ServiceTable _table;
@@ -33,7 +32,7 @@ namespace Microsoft.Extensions.DependencyInjection
         // CallSiteRuntimeResolver is stateless so can be shared between all instances
         private static readonly CallSiteRuntimeResolver _callSiteRuntimeResolver = new CallSiteRuntimeResolver();
 
-        public ServiceProvider(IEnumerable<ServiceDescriptor> serviceDescriptors, ServiceProviderOptions options)
+        internal ServiceProvider(IEnumerable<ServiceDescriptor> serviceDescriptors, ServiceProviderOptions options)
         {
             Root = this;
 

--- a/src/Microsoft.Extensions.DependencyInjection/exceptions.netcore.json
+++ b/src/Microsoft.Extensions.DependencyInjection/exceptions.netcore.json
@@ -1,0 +1,9 @@
+[
+  {
+    "OldTypeId": "public static class Microsoft.Extensions.DependencyInjection.ServiceCollectionContainerBuilderExtensions",
+    "OldMemberId": "public static System.IServiceProvider BuildServiceProvider(this Microsoft.Extensions.DependencyInjection.IServiceCollection services)",
+    "NewTypeId": "public static class Microsoft.Extensions.DependencyInjection.ServiceCollectionContainerBuilderExtensions",
+    "NewMemberId": "public static Microsoft.Extensions.DependencyInjection.ServiceProvider BuildServiceProvider(this Microsoft.Extensions.DependencyInjection.IServiceCollection services)",
+    "Kind": "Modification"
+  }
+]

--- a/test/Microsoft.Extensions.DependencyInjection.Tests/ServiceLookup/ServiceTest.cs
+++ b/test/Microsoft.Extensions.DependencyInjection.Tests/ServiceLookup/ServiceTest.cs
@@ -397,7 +397,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 collection.Add(descriptor);
             }
 
-            return (ServiceProvider)collection.BuildServiceProvider();
+            return collection.BuildServiceProvider();
         }
 
         private static IEnumerable<Type> GetParameters(ConstructorCallSite constructorCallSite) =>

--- a/test/Microsoft.Extensions.DependencyInjection.Tests/ServiceProviderContainerTests.cs
+++ b/test/Microsoft.Extensions.DependencyInjection.Tests/ServiceProviderContainerTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             var provider = serviceCollection.BuildServiceProvider();
             provider.GetService<Disposable>();
 
-            ((IDisposable)provider).Dispose();
+            provider.Dispose();
 
             Assert.False(disposable.Disposed);
         }


### PR DESCRIPTION
- Make ServiceProvider public so that it can be returned
from BuildServiceProvider().
- Make it sealed since it can't really be extended.
- Changed tests to stop down casting.

#338 