### PR TITLE
implement partially closed generics service.

### DIFF
--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/PartiallyClosedGenericsService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/PartiallyClosedGenericsService.cs
@@ -1,0 +1,256 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Linq;
+
+namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
+{
+    internal class PartiallyClosedGenericsService : IGenericService
+    {
+        private readonly ServiceDescriptor _descriptor;
+        private readonly GenericTypeTree _tree;
+
+        public PartiallyClosedGenericsService(ServiceDescriptor descriptor)
+        {
+            this._descriptor = descriptor;
+            this._tree = new GenericTypeTree(descriptor.ServiceType, descriptor.ImplementationType);
+        }
+
+        public ServiceLifetime Lifetime
+        {
+            get { return _descriptor.Lifetime; }
+        }
+
+        public IService GetService(Type closedServiceType)
+        {
+            if (this._tree.TryMakeGenericType(closedServiceType, out var closedImplType))
+            {
+                return new Service(new ServiceDescriptor(closedServiceType, closedImplType, this.Lifetime));
+            }
+            return null;
+        }
+
+        public class GenericTypeTree
+        {
+            [DebuggerDisplay("{DebuggerDisplay()}")]
+            private class Node
+            {
+                private readonly Type _type;
+                private readonly TypeInfo _typeInfo;
+                private readonly bool _isGenericType;
+                private readonly Node[] _genericArguments;
+                private readonly bool _isGenericParameter;
+
+                public Node(GenericTypeTree tree, Type type)
+                {
+                    this._type = type;
+                    this._typeInfo = type.GetTypeInfo();
+                    this._isGenericType = this._typeInfo.IsGenericType;
+                    if (this._isGenericType)
+                    {
+                        var args = this._typeInfo.IsGenericTypeDefinition
+                            ? this._typeInfo.GenericTypeParameters
+                            : this._typeInfo.GenericTypeArguments;
+                        this._genericArguments = args.Select(z => new Node(tree, z)).ToArray();
+                    }
+                    else
+                    {
+                        this._isGenericParameter = type.IsGenericParameter;
+                        if (this._isGenericParameter)
+                        {
+                            if (!tree._genericParameterConstraints.ContainsKey(type.Name))
+                            {
+                                tree._genericParameterConstraints[type.Name] =
+                                    new GenericParameterConstraint(type, this._typeInfo);
+                            }
+                        }
+                    }
+                }
+
+                public bool TryResolveGenericParameter(Type type, Dictionary<string, Type> genericParameterMap)
+                {
+                    if (this._isGenericType)
+                    {
+                        var typeInfo = type.GetTypeInfo();
+                        if (!typeInfo.IsGenericType)
+                        {
+                            return false;
+                        }
+                        var args = typeInfo.GenericTypeArguments;
+                        if (args.Length != this._genericArguments.Length)
+                        {
+                            return false;
+                        }
+                        for (var i = 0; i < args.Length; i++)
+                        {
+                            if (!this._genericArguments[i].TryResolveGenericParameter(args[i], genericParameterMap))
+                            {
+                                return false;
+                            }
+                        }
+                    }
+                    else if (this._isGenericParameter)
+                    {
+                        if (genericParameterMap.TryGetValue(this._type.Name, out var t))
+                        {
+                            if (t != type) return false;
+                        }
+                        else
+                        {
+                            genericParameterMap.Add(this._type.Name, type);
+                        }
+                    }
+                    else
+                    {
+                        if (type != this._type) return false;
+                    }
+
+                    return true;
+                }
+
+                public string DebuggerDisplay()
+                {
+                    if (this._isGenericType)
+                    {
+                        var name = this._type.Name;
+                        var index = name.IndexOf('`');
+                        name = name.Substring(0, index);
+                        return $"{name}<{string.Join(", ", this._genericArguments.Select(z => z.DebuggerDisplay()).ToArray())}>";
+                    }
+                    else
+                    {
+                        return this._type.Name;
+                    }
+                }
+            }
+
+            private class GenericParameterConstraint
+            {
+                private readonly Type _type;
+                private readonly TypeInfo _typeInfo;
+                private readonly GenericParameterAttributes _genericParameterAttributes;
+                private readonly TypeInfo[] _genericParameterConstraints;
+
+                public GenericParameterConstraint(Type type, TypeInfo typeInfo)
+                {
+                    this._type = type;
+                    this._typeInfo = typeInfo;
+                    this._genericParameterAttributes = typeInfo.GenericParameterAttributes;
+                    this._genericParameterConstraints = typeInfo
+                        .GetGenericParameterConstraints()
+                        .Select(z => z.GetTypeInfo())
+                        .ToArray();
+                }
+
+                public bool MatchConstraints(Dictionary<string, Type> genericParameterMap)
+                {
+                    if (!genericParameterMap.TryGetValue(this._type.Name, out var type))
+                    {
+                        return false;
+                    }
+
+                    if (this.IsValueType || this.IsClass || this.HasDefaultConstructor ||
+                        this._genericParameterConstraints.Length > 0)
+                    {
+                        var typeInfo = type.GetTypeInfo();
+
+                        if (this.IsValueType && !typeInfo.IsValueType)
+                        {
+                            return false;
+                        }
+
+                        if (this.IsClass && typeInfo.IsValueType)
+                        {
+                            return false;
+                        }
+
+                        if (this.HasDefaultConstructor &&
+                            !typeInfo.IsValueType &&
+                            typeInfo.DeclaredConstructors.FirstOrDefault(z => z.GetParameters().Length == 0) == null)
+                        {
+                            return false;
+                        }
+                        
+                        var result = this._genericParameterConstraints.Length == 0 ||
+                                     this._genericParameterConstraints.All(z => z.IsAssignableFrom(typeInfo));
+                        return result;
+                    }
+                    else
+                    {
+                        return true;
+                    }
+                }
+
+                private bool IsValueType => GenericParameterAttributes.NotNullableValueTypeConstraint
+                    == (this._genericParameterAttributes & GenericParameterAttributes.NotNullableValueTypeConstraint);
+
+                private bool IsClass => GenericParameterAttributes.ReferenceTypeConstraint
+                    == (this._genericParameterAttributes & GenericParameterAttributes.ReferenceTypeConstraint);
+
+                private bool HasDefaultConstructor => GenericParameterAttributes.DefaultConstructorConstraint
+                    == (this._genericParameterAttributes & GenericParameterAttributes.DefaultConstructorConstraint);
+            }
+
+            private readonly Dictionary<string, GenericParameterConstraint> _genericParameterConstraints
+                = new Dictionary<string, GenericParameterConstraint>();
+            private readonly Node _serviceNode;
+            private readonly Type _implementationType;
+            private readonly TypeInfo _implementationTypeInfo;
+            private readonly string[] _implementationTypeGenericParameterNames;
+
+            public GenericTypeTree(Type serviceType, Type implementationType)
+            {
+                this._serviceNode = new Node(this, serviceType);
+                this._implementationType = implementationType;
+                this._implementationTypeInfo = implementationType.GetTypeInfo();
+                if (!this._implementationTypeInfo.IsGenericTypeDefinition)
+                {
+                    throw new ArgumentException($"implementation type {this._implementationTypeInfo} should be generic type definition.");
+                }
+                this._implementationTypeGenericParameterNames = this._implementationTypeInfo
+                    .GenericTypeParameters
+                    .Select(z => z.Name)
+                    .ToArray();
+                if (this._implementationTypeGenericParameterNames.Length != this._genericParameterConstraints.Count)
+                {
+                    throw new ArgumentException("generic parameter count is not match.");
+                }
+                if (this._implementationTypeGenericParameterNames.Any(z => !this._genericParameterConstraints.ContainsKey(z)))
+                {
+                    throw new ArgumentException("generic parameter is not match.");
+                }
+            }
+
+            public bool TryMakeGenericType(Type closedServiceType, out Type closedImplType)
+            {
+                var destTypeInfo = closedServiceType.GetTypeInfo();
+                if (destTypeInfo.ContainsGenericParameters)
+                {
+                    closedImplType = null;
+                    return false;
+                }
+                var map = new Dictionary<string, Type>();
+                if (!this._serviceNode.TryResolveGenericParameter(closedServiceType, map))
+                {
+                    closedImplType = null;
+                    return false;
+                }
+                foreach (var kvp in this._genericParameterConstraints)
+                {
+                    if (!kvp.Value.MatchConstraints(map))
+                    {
+                        closedImplType = null;
+                        return false;
+                    }
+                }
+                var types = this._implementationTypeGenericParameterNames.Select(z => map[z]).ToArray();
+                closedImplType = this._implementationType.MakeGenericType(types);
+                return true;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ServiceTable.cs
+++ b/src/Microsoft.Extensions.DependencyInjection/ServiceLookup/ServiceTable.cs
@@ -49,6 +49,11 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
                     Add(descriptor.ServiceType, new GenericService(descriptor));
                 }
+                else if (serviceTypeInfo.ContainsGenericParameters)
+                {
+                    var serviceType = descriptor.ServiceType.GetGenericTypeDefinition();
+                    Add(serviceType, new PartiallyClosedGenericsService(descriptor));
+                }
                 else if (descriptor.ImplementationInstance != null)
                 {
                     Add(descriptor.ServiceType, new InstanceService(descriptor));

--- a/test/Microsoft.Extensions.DependencyInjection.Tests/PartiallyClosedGenericsServiceTest.cs
+++ b/test/Microsoft.Extensions.DependencyInjection.Tests/PartiallyClosedGenericsServiceTest.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection.Specification;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+using System.Diagnostics;
+using Microsoft.Extensions.DependencyInjection.ServiceLookup;
+
+namespace Microsoft.Extensions.DependencyInjection.Tests
+{
+    public class PartiallyClosedGenericsServiceTest : DependencyInjectionSpecificationTests
+    {
+        protected override IServiceProvider CreateServiceProvider(IServiceCollection serviceCollection) =>
+               serviceCollection.BuildServiceProvider();
+
+        public interface ITestInterface1<TI1, TI2, TI3>
+        {
+
+        }
+
+        public class TestClass1<TC1, TC2> : ITestInterface1<TC1, TC2, TC1>
+        {
+
+        }
+
+        public class TestClass2<TC1> : ITestInterface1<TC1, List<TC1>, Dictionary<string, HashSet<TC1>>>
+        {
+
+        }
+
+        [Fact]
+        public void TestDefault()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient(
+                typeof(TestClass1<,>).GetTypeInfo().GetInterfaces().Single(),
+                typeof(TestClass1<,>));
+            serviceCollection.AddTransient(
+                typeof(TestClass2<>).GetTypeInfo().GetInterfaces().Single(),
+                typeof(TestClass2<>));
+
+            var provider = serviceCollection.BuildServiceProvider();
+            Assert.IsType(typeof(TestClass1<int, int>), 
+                provider.GetRequiredService<ITestInterface1<int, int, int>>());
+            Assert.IsType(typeof(TestClass1<string, int>), 
+                provider.GetRequiredService<ITestInterface1<string, int, string>>());
+            Assert.Null(provider.GetService<ITestInterface1<int, double, string>>());
+
+            Assert.IsType(typeof(TestClass2<string>), 
+                provider.GetRequiredService<ITestInterface1<string, List<string>, Dictionary<string, HashSet<string>>>>());
+            Assert.Null(provider.GetService<ITestInterface1<string, List<string>, Dictionary<object, HashSet<string>>>>());
+            Assert.Null(provider.GetService<ITestInterface1<string, List<string>, Dictionary<string, HashSet<int>>>>());
+            Assert.Null(provider.GetService<ITestInterface1<string, List<int>, Dictionary<string, HashSet<string>>>>());
+            Assert.Null(provider.GetService<ITestInterface1<int, List<string>, Dictionary<string, HashSet<string>>>>());
+        }
+
+        public class TestClass3<TC1> : ITestInterface1<TC1, List<TC1>, Dictionary<string, HashSet<TC1>>>
+            where TC1 : class
+        {
+
+        }
+
+        public class TestClass4<TC1> : ITestInterface1<TC1, List<TC1>, Dictionary<string, HashSet<TC1>>>
+            where TC1 : struct
+        {
+
+        }
+
+        public class TestClass5<TC1> : ITestInterface1<TC1, List<TC1>, Dictionary<string, HashSet<TC1>>>
+            where TC1 : class, IDisposable
+        {
+
+        }
+
+        public class TestClass6<TC1> : ITestInterface1<TC1, List<TC1>, Dictionary<string, HashSet<TC1>>>
+            where TC1 : class, IDisposable, new()
+        {
+
+        }
+
+        public class TestClass7<TC1> : ITestInterface1<TC1, List<TC1>, Dictionary<string, HashSet<TC1>>>
+            where TC1 : struct, IDisposable
+        {
+
+        }
+
+        public class SimpleDisposableClass : IDisposable
+        {
+            public SimpleDisposableClass(int _) { }
+
+            public void Dispose()
+            {
+                
+            }
+        }
+
+        public class SimpleDisposableClass_New : IDisposable
+        {
+            public void Dispose()
+            {
+
+            }
+        }
+
+        public struct SimpleDisposableValue : IDisposable
+        {
+            public void Dispose()
+            {
+
+            }
+        }
+
+        [Fact]
+        public void TestGenericParameterConstraint()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient(
+                typeof(TestClass3<>).GetTypeInfo().GetInterfaces().Single(),
+                typeof(TestClass3<>));
+            serviceCollection.AddTransient(
+                typeof(TestClass4<>).GetTypeInfo().GetInterfaces().Single(),
+                typeof(TestClass4<>));
+            serviceCollection.AddTransient(
+                typeof(TestClass5<>).GetTypeInfo().GetInterfaces().Single(),
+                typeof(TestClass5<>));
+            serviceCollection.AddTransient(
+                typeof(TestClass6<>).GetTypeInfo().GetInterfaces().Single(),
+                typeof(TestClass6<>));
+            serviceCollection.AddTransient(
+                typeof(TestClass7<>).GetTypeInfo().GetInterfaces().Single(),
+                typeof(TestClass7<>));
+
+            var provider = serviceCollection.BuildServiceProvider();
+
+            Assert.IsType(typeof(TestClass4<int>),
+                provider.GetRequiredService<ITestInterface1<int, List<int>, Dictionary<string, HashSet<int>>>>());
+
+            Assert.IsType(typeof(TestClass3<string>),
+                provider.GetRequiredService<
+                    ITestInterface1<string,
+                    List<string>,
+                    Dictionary<string, HashSet<string>>>>());
+
+            Assert.IsType(typeof(TestClass6<SimpleDisposableClass_New>),
+                provider.GetRequiredService<
+                    ITestInterface1<SimpleDisposableClass_New,
+                    List<SimpleDisposableClass_New>,
+                    Dictionary<string, HashSet<SimpleDisposableClass_New>>>>());
+
+            Assert.IsType(typeof(TestClass5<SimpleDisposableClass>),
+                provider.GetRequiredService<
+                    ITestInterface1<SimpleDisposableClass,
+                    List<SimpleDisposableClass>,
+                    Dictionary<string, HashSet<SimpleDisposableClass>>>>());
+
+            Assert.IsType(typeof(TestClass7<SimpleDisposableValue>),
+                provider.GetRequiredService<
+                    ITestInterface1<SimpleDisposableValue,
+                    List<SimpleDisposableValue>,
+                    Dictionary<string, HashSet<SimpleDisposableValue>>>>());
+        }
+
+        [Fact]
+        public void TestBuilder()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient(
+                typeof(TestClass1<,>).GetTypeInfo().GetInterfaces().Single(),
+                typeof(TestClass2<>));
+            Assert.Throws<ArgumentException>(() => serviceCollection.BuildServiceProvider());
+        }
+    }
+}


### PR DESCRIPTION
- implement partially closed generics service.
- add unittest.

now I can use:

``` cs
public interface ITestInterface1<TI1, TI2, TI3> { }
public class TestClass2<TC1> : ITestInterface1<TC1, List<TC1>, Dictionary<string, HashSet<TC1>>> { }

var serviceCollection = new ServiceCollection();
serviceCollection.AddTransient(
    typeof(TestClass1<,>).GetTypeInfo().GetInterfaces().Single(),
    typeof(TestClass1<,>));
var provider = serviceCollection.BuildServiceProvider();
provider.GetRequiredService<ITestInterface1<string, List<string>, Dictionary<string, HashSet<string>>>>();
```

see #521.