### PR TITLE
Update test SDK and xunit version

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -6,7 +6,7 @@
     <InternalAspNetCoreSdkVersion>2.1.0-*</InternalAspNetCoreSdkVersion>
     <MoqVersion>4.7.1</MoqVersion>
     <NETStandardImplicitPackageVersion>$(BundledNETStandardPackageVersion)</NETStandardImplicitPackageVersion>
-    <TestSdkVersion>15.0.0</TestSdkVersion>
-    <XunitVersion>2.2.0</XunitVersion>
+    <TestSdkVersion>15.3.0-*</TestSdkVersion>
+    <XunitVersion>2.3.0-beta2-*</XunitVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.Extensions.DependencyInjection.Specification.Tests/Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj
+++ b/src/Microsoft.Extensions.DependencyInjection.Specification.Tests/Microsoft.Extensions.DependencyInjection.Specification.Tests.csproj
@@ -19,8 +19,4 @@
     <PackageReference Include="xunit.extensibility.core" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.Extensions.DependencyInjection.Tests/Microsoft.Extensions.DependencyInjection.Tests.csproj
+++ b/test/Microsoft.Extensions.DependencyInjection.Tests/Microsoft.Extensions.DependencyInjection.Tests.csproj
@@ -20,8 +20,4 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/test/Microsoft.Extensions.DependencyInjection.Tests/ServiceLookup/ServiceTest.cs
+++ b/test/Microsoft.Extensions.DependencyInjection.Tests/ServiceLookup/ServiceTest.cs
@@ -263,7 +263,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         [Theory]
         [InlineData(typeof(TypeWithMultipleParameterizedConstructors))]
         [InlineData(typeof(TypeWithSupersetConstructors))]
-        [InlineData(typeof(TypeWithSupersetConstructors))]
         public void CreateCallSite_ThrowsIfTypeHasNoConstructurWithResolvableParameters(Type type)
         {
             // Arrange


### PR DESCRIPTION
Update to Microsoft.NET.Test.Sdk 15.3.0 and xunit 2.3.0-beta2.

Cleanup a duplicate test (thanks to better xunit diagnostics in xunit 2.3 :) )

cref https://github.com/aspnet/Coherence-Signed/issues/49

cc @Eilon - OSS approval for new xunit version