### PR TITLE
Change 'ambigious' to 'ambiguous'  in exception message

### DIFF
--- a/src/DI/Properties/Resources.Designer.cs
+++ b/src/DI/Properties/Resources.Designer.cs
@@ -11,18 +11,18 @@ namespace Microsoft.Extensions.DependencyInjection
             = new ResourceManager("Microsoft.Extensions.DependencyInjection.Resources", typeof(Resources).GetTypeInfo().Assembly);
 
         /// <summary>
-        /// Unable to activate type '{0}'. The following constructors are ambigious:
+        /// Unable to activate type '{0}'. The following constructors are ambiguous:
         /// </summary>
-        internal static string AmbigiousConstructorException
+        internal static string AmbiguousConstructorException
         {
-            get => GetString("AmbigiousConstructorException");
+            get => GetString("AmbiguousConstructorException");
         }
 
         /// <summary>
-        /// Unable to activate type '{0}'. The following constructors are ambigious:
+        /// Unable to activate type '{0}'. The following constructors are ambiguous:
         /// </summary>
-        internal static string FormatAmbigiousConstructorException(object p0)
-            => string.Format(CultureInfo.CurrentCulture, GetString("AmbigiousConstructorException"), p0);
+        internal static string FormatAmbiguousConstructorException(object p0)
+            => string.Format(CultureInfo.CurrentCulture, GetString("AmbiguousConstructorException"), p0);
 
         /// <summary>
         /// Unable to resolve service for type '{0}' while attempting to activate '{1}'.

--- a/src/DI/Resources.resx
+++ b/src/DI/Resources.resx
@@ -117,8 +117,8 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AmbigiousConstructorException" xml:space="preserve">
-    <value>Unable to activate type '{0}'. The following constructors are ambigious:</value>
+  <data name="AmbiguousConstructorException" xml:space="preserve">
+    <value>Unable to activate type '{0}'. The following constructors are ambiguous:</value>
   </data>
   <data name="CannotResolveService" xml:space="preserve">
     <value>Unable to resolve service for type '{0}' while attempting to activate '{1}'.</value>

--- a/src/DI/ServiceLookup/CallSiteFactory.cs
+++ b/src/DI/ServiceLookup/CallSiteFactory.cs
@@ -294,10 +294,10 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
                         if (!bestConstructorParameterTypes.IsSupersetOf(parameters.Select(p => p.ParameterType)))
                         {
-                            // Ambigious match exception
+                            // Ambiguous match exception
                             var message = string.Join(
                                 Environment.NewLine,
-                                Resources.FormatAmbigiousConstructorException(implementationType),
+                                Resources.FormatAmbiguousConstructorException(implementationType),
                                 bestConstructor,
                                 constructors[i]);
                             throw new InvalidOperationException(message);

--- a/test/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
+++ b/test/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
@@ -368,7 +368,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var expectedMessage =
                 string.Join(
                     Environment.NewLine,
-                    $"Unable to activate type '{type}'. The following constructors are ambigious:",
+                    $"Unable to activate type '{type}'. The following constructors are ambiguous:",
                     GetConstructor(type, expectedConstructorParameterTypes[0]),
                     GetConstructor(type, expectedConstructorParameterTypes[1]));
 
@@ -383,7 +383,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             // Arrange
             var type = typeof(TypeWithGenericServices);
-            var expectedMessage = $"Unable to activate type '{type}'. The following constructors are ambigious:";
+            var expectedMessage = $"Unable to activate type '{type}'. The following constructors are ambiguous:";
 
             var callSiteFactory = GetCallSiteFactory(
                 new ServiceDescriptor(type, type, ServiceLifetime.Transient),


### PR DESCRIPTION
Fixed small typo in `AmbiguousConstructorException` resource string.