### PR TITLE
[WIP] Use TypeNameHelper for type display in exception messages

### DIFF
--- a/src/DI.Abstractions/DI.Abstractions.csproj
+++ b/src/DI.Abstractions/DI.Abstractions.csproj
@@ -15,4 +15,8 @@ Microsoft.Extensions.DependencyInjection.IServiceCollection</Description>
     <Compile Include="..\..\shared\Microsoft.Extensions.ActivatorUtilities.Sources\*.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.TypeNameHelper.Sources" PrivateAssets="All" />
+  </ItemGroup>
+
 </Project>

--- a/src/DI.Abstractions/Extensions/ServiceCollectionDescriptorExtensions.cs
+++ b/src/DI.Abstractions/Extensions/ServiceCollectionDescriptorExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection.Abstractions;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.Extensions.DependencyInjection.Extensions
 {
@@ -603,8 +604,8 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
             {
                 throw new ArgumentException(
                     Resources.FormatTryAddIndistinguishableTypeToEnumerable(
-                        implementationType,
-                        descriptor.ServiceType),
+                        TypeNameHelper.GetTypeDisplayName(implementationType),
+                        TypeNameHelper.GetTypeDisplayName(descriptor.ServiceType)),
                     nameof(descriptor));
             }
 

--- a/src/DI.Abstractions/ServiceProviderServiceExtensions.cs
+++ b/src/DI.Abstractions/ServiceProviderServiceExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.DependencyInjection.Abstractions;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -56,7 +57,7 @@ namespace Microsoft.Extensions.DependencyInjection
             var service = provider.GetService(serviceType);
             if (service == null)
             {
-                throw new InvalidOperationException(Resources.FormatNoServiceRegistered(serviceType));
+                throw new InvalidOperationException(Resources.FormatNoServiceRegistered(TypeNameHelper.GetTypeDisplayName(serviceType)));
             }
 
             return service;

--- a/src/DI/ServiceLookup/CallSiteFactory.cs
+++ b/src/DI/ServiceLookup/CallSiteFactory.cs
@@ -299,7 +299,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
                         if (!bestConstructorParameterTypes.IsSupersetOf(parameters.Select(p => p.ParameterType)))
                         {
-                            // Ambiguous match exception
+                            // Ambigious match exception
                             var message = string.Join(
                                 Environment.NewLine,
                                 Resources.FormatAmbigiousConstructorException(TypeNameHelper.GetTypeDisplayName(implementationType)),

--- a/src/DI/ServiceLookup/CallSiteFactory.cs
+++ b/src/DI/ServiceLookup/CallSiteFactory.cs
@@ -34,14 +34,16 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     if (implementationTypeInfo == null || !implementationTypeInfo.IsGenericTypeDefinition)
                     {
                         throw new ArgumentException(
-                            Resources.FormatOpenGenericServiceRequiresOpenGenericImplementation(descriptor.ServiceType),
+                            Resources.FormatOpenGenericServiceRequiresOpenGenericImplementation(TypeNameHelper.GetTypeDisplayName(descriptor.ServiceType)),
                             nameof(descriptors));
                     }
 
                     if (implementationTypeInfo.IsAbstract || implementationTypeInfo.IsInterface)
                     {
                         throw new ArgumentException(
-                            Resources.FormatTypeCannotBeActivated(descriptor.ImplementationType, descriptor.ServiceType));
+                            Resources.FormatTypeCannotBeActivated(
+                                TypeNameHelper.GetTypeDisplayName(descriptor.ImplementationType),
+                                TypeNameHelper.GetTypeDisplayName(descriptor.ServiceType)));
                     }
                 }
                 else if (descriptor.ImplementationInstance == null && descriptor.ImplementationFactory == null)
@@ -54,7 +56,9 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                         implementationTypeInfo.IsInterface)
                     {
                         throw new ArgumentException(
-                            Resources.FormatTypeCannotBeActivated(descriptor.ImplementationType, descriptor.ServiceType));
+                            Resources.FormatTypeCannotBeActivated(
+                                TypeNameHelper.GetTypeDisplayName(descriptor.ImplementationType),
+                                TypeNameHelper.GetTypeDisplayName(descriptor.ServiceType)));
                     }
                 }
 
@@ -237,7 +241,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
             if (constructors.Length == 0)
             {
-                throw new InvalidOperationException(Resources.FormatNoConstructorMatch(implementationType));
+                throw new InvalidOperationException(
+                    Resources.FormatNoConstructorMatch(TypeNameHelper.GetTypeDisplayName(implementationType)));
             }
             else if (constructors.Length == 1)
             {
@@ -294,10 +299,10 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
                         if (!bestConstructorParameterTypes.IsSupersetOf(parameters.Select(p => p.ParameterType)))
                         {
-                            // Ambigious match exception
+                            // Ambiguous match exception
                             var message = string.Join(
                                 Environment.NewLine,
-                                Resources.FormatAmbigiousConstructorException(implementationType),
+                                Resources.FormatAmbigiousConstructorException(TypeNameHelper.GetTypeDisplayName(implementationType)),
                                 bestConstructor,
                                 constructors[i]);
                             throw new InvalidOperationException(message);
@@ -309,7 +314,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             if (bestConstructor == null)
             {
                 throw new InvalidOperationException(
-                    Resources.FormatUnableToActivateTypeException(implementationType));
+                    Resources.FormatUnableToActivateTypeException(TypeNameHelper.GetTypeDisplayName(implementationType)));
             }
             else
             {
@@ -342,8 +347,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     if (throwIfCallSiteNotFound)
                     {
                         throw new InvalidOperationException(Resources.FormatCannotResolveService(
-                            parameters[index].ParameterType,
-                            implementationType));
+                            TypeNameHelper.GetTypeDisplayName(parameters[index].ParameterType),
+                            TypeNameHelper.GetTypeDisplayName(implementationType)));
                     }
 
                     return null;

--- a/src/DI/ServiceLookup/CallSiteValidator.cs
+++ b/src/DI/ServiceLookup/CallSiteValidator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
@@ -29,14 +30,15 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 if (serviceType == scopedService)
                 {
                     throw new InvalidOperationException(
-                        Resources.FormatDirectScopedResolvedFromRootException(serviceType,
+                        Resources.FormatDirectScopedResolvedFromRootException(
+                            TypeNameHelper.GetTypeDisplayName(serviceType),
                             nameof(ServiceLifetime.Scoped).ToLowerInvariant()));
                 }
 
                 throw new InvalidOperationException(
                     Resources.FormatScopedResolvedFromRootException(
-                        serviceType,
-                        scopedService,
+                        TypeNameHelper.GetTypeDisplayName(serviceType),
+                        TypeNameHelper.GetTypeDisplayName(scopedService),
                         nameof(ServiceLifetime.Scoped).ToLowerInvariant()));
             }
         }
@@ -91,8 +93,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             if (state.Singleton != null)
             {
                 throw new InvalidOperationException(Resources.FormatScopedInSingletonException(
-                    scopedCallSite.ServiceType,
-                    state.Singleton.ServiceType,
+                    TypeNameHelper.GetTypeDisplayName(scopedCallSite.ServiceType),
+                    TypeNameHelper.GetTypeDisplayName(state.Singleton.ServiceType),
                     nameof(ServiceLifetime.Scoped).ToLowerInvariant(),
                     nameof(ServiceLifetime.Singleton).ToLowerInvariant()
                     ));

--- a/test/DI.Tests/ServiceCollectionServiceExtensionsTest.cs
+++ b/test/DI.Tests/ServiceCollectionServiceExtensionsTest.cs
@@ -7,8 +7,6 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 using Xunit;
 
-using AbstractionResources = Microsoft.Extensions.DependencyInjection.Abstractions.Resources;
-
 namespace Microsoft.Extensions.DependencyInjection
 {
     public class ServiceCollectionServiceExtensionsTest
@@ -318,19 +316,19 @@ namespace Microsoft.Extensions.DependencyInjection
             get
             {
                 var serviceType = typeof(IFakeService);
-                var implementationType = typeof(FakeService);
-                var objectType = typeof(object);
+                var serviceTypeName = "Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeService";
+                var objectTypeName = "object";
 
-                return new TheoryData<ServiceDescriptor, Type, Type>
+                return new TheoryData<ServiceDescriptor, string, string>
                 {
-                    { ServiceDescriptor.Transient<IFakeService>(s => new FakeService()), serviceType, serviceType },
-                    { ServiceDescriptor.Transient(serviceType, s => new FakeService()), serviceType, objectType },
+                    { ServiceDescriptor.Transient<IFakeService>(s => new FakeService()), serviceTypeName, serviceTypeName },
+                    { ServiceDescriptor.Transient(serviceType, s => new FakeService()), serviceTypeName, objectTypeName },
 
-                    { ServiceDescriptor.Scoped<IFakeService>(s => new FakeService()), serviceType, serviceType },
-                    { ServiceDescriptor.Scoped(serviceType, s => new FakeService()), serviceType, objectType },
+                    { ServiceDescriptor.Scoped<IFakeService>(s => new FakeService()), serviceTypeName, serviceTypeName },
+                    { ServiceDescriptor.Scoped(serviceType, s => new FakeService()), serviceTypeName, objectTypeName },
 
-                    { ServiceDescriptor.Singleton<IFakeService>(s => new FakeService()), serviceType, serviceType },
-                    { ServiceDescriptor.Singleton(serviceType, s => new FakeService()), serviceType, objectType },
+                    { ServiceDescriptor.Singleton<IFakeService>(s => new FakeService()), serviceTypeName, serviceTypeName },
+                    { ServiceDescriptor.Singleton(serviceType, s => new FakeService()), serviceTypeName, objectTypeName },
                 };
             }
         }
@@ -339,8 +337,8 @@ namespace Microsoft.Extensions.DependencyInjection
         [MemberData(nameof(TryAddEnumerableInvalidImplementationTypeData))]
         public void TryAddEnumerable_ThrowsWhenAddingIndistinguishableImplementationType(
             ServiceDescriptor descriptor,
-            Type serviceType,
-            Type implementationType)
+            string serviceTypeName,
+            string implementationTypeName)
         {
             // Arrange
             var collection = new ServiceCollection();
@@ -349,7 +347,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ExceptionAssert.ThrowsArgument(
                 () => collection.TryAddEnumerable(descriptor),
                 "descriptor",
-                AbstractionResources.FormatTryAddIndistinguishableTypeToEnumerable(implementationType, serviceType));
+                $"Implementation type cannot be '{implementationTypeName}' because it is indistinguishable from other services registered for '{serviceTypeName}'.");
         }
 
         [Fact]

--- a/test/DI.Tests/ServiceProviderContainerTests.cs
+++ b/test/DI.Tests/ServiceProviderContainerTests.cs
@@ -74,18 +74,57 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                 $"'{typeof(DependOnNonexistentService)}'.", ex.Message);
         }
 
+        public static IEnumerable<object[]> ServiceProviderWithUnresolvableTypes()
+        {
+            // GenericTypeDefintion, Abstract GenericTypeDefintion
+            yield return new object[]
+            {
+                typeof(IFakeOpenGenericService<>),
+                typeof(AbstractFakeOpenGenericService<>),
+                "Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeOpenGenericService",
+                "Microsoft.Extensions.DependencyInjection.Tests.ServiceProviderContainerTests+AbstractFakeOpenGenericService"
+            };
+
+            // GenericTypeDefintion, Interface GenericTypeDefintion
+            yield return new object[]
+            {
+                typeof(ICollection<>),
+                typeof(IList<>),
+                "System.Collections.Generic.ICollection",
+                "System.Collections.Generic.IList"
+            };
+
+            // Implementation type is GenericTypeDefintion
+            yield return new object[]
+            {
+                typeof(IList<int>),
+                typeof(List<>),
+                "System.Collections.Generic.IList<int>",
+                "System.Collections.Generic.List"
+            };
+
+            // Implementation type is Abstract
+            yield return new object[]
+            {
+                typeof(IFakeService),
+                typeof(AbstractClass),
+                "Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeService",
+                "Microsoft.Extensions.DependencyInjection.Tests.Fakes.AbstractClass"
+            };
+
+            // Implementation type is Interface
+            yield return new object[]
+            {
+                typeof(IFakeEveryService),
+                typeof(IFakeService),
+                "Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeEveryService",
+                "Microsoft.Extensions.DependencyInjection.Specification.Fakes.IFakeService"
+            };
+        }
+
         [Theory]
-        // GenericTypeDefintion, Abstract GenericTypeDefintion
-        [InlineData(typeof(IFakeOpenGenericService<>), typeof(AbstractFakeOpenGenericService<>))]
-        // GenericTypeDefintion, Interface GenericTypeDefintion
-        [InlineData(typeof(ICollection<>), typeof(IList<>))]
-        // Implementation type is GenericTypeDefintion
-        [InlineData(typeof(IList<int>), typeof(List<>))]
-        // Implementation type is Abstract
-        [InlineData(typeof(IFakeService), typeof(AbstractClass))]
-        // Implementation type is Interface
-        [InlineData(typeof(IFakeEveryService), typeof(IFakeService))]
-        public void CreatingServiceProviderWithUnresolvableTypesThrows(Type serviceType, Type implementationType)
+        [MemberData(nameof(ServiceProviderWithUnresolvableTypes))]
+        public void CreatingServiceProviderWithUnresolvableTypesThrows(Type serviceType, Type implementationType, string serviceTypeName, string implementationTypeName)
         {
             // Arrange
             var serviceCollection = new ServiceCollection();
@@ -94,7 +133,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             // Act and Assert
             var exception = Assert.Throws<ArgumentException>(() => serviceCollection.BuildServiceProvider());
             Assert.Equal(
-                $"Cannot instantiate implementation type '{implementationType}' for service type '{serviceType}'.",
+                $"Cannot instantiate implementation type '{implementationTypeName}' for service type '{serviceTypeName}'.",
                 exception.Message);
         }
 

--- a/test/DI.Tests/ServiceTableTest.cs
+++ b/test/DI.Tests/ServiceTableTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             ExceptionAssert.ThrowsArgument(
                 () => new CallSiteFactory(serviceDescriptors),
                 "descriptors",
-                $"Open generic service type '{typeof(IList<>)}' requires registering an open generic implementation type.");
+                "Open generic service type 'System.Collections.Generic.IList' requires registering an open generic implementation type.");
         }
 
         public static TheoryData Constructor_WithInstance_ThrowsIfServiceTypeIsOpenGenericData =>
@@ -51,7 +51,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var ex = ExceptionAssert.ThrowsArgument(
                 () => new CallSiteFactory(serviceDescriptors),
                 "descriptors",
-                $"Open generic service type '{typeof(IEnumerable<>)}' requires registering an open generic implementation type.");
+                "Open generic service type 'System.Collections.Generic.IEnumerable' requires registering an open generic implementation type.");
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var ex = ExceptionAssert.ThrowsArgument(
                 () => new CallSiteFactory(serviceDescriptors),
                 "descriptors",
-                $"Open generic service type '{typeof(Tuple<>)}' requires registering an open generic implementation type.");
+                "Open generic service type 'System.Tuple' requires registering an open generic implementation type.");
         }
     }
 }


### PR DESCRIPTION
Since `CircularReferenceException` use `TypeNameHelper`, I think it would be consistent if other exception will use it for type display.

I had to add package reference on `Microsoft.Extensions.TypeNameHelper.Sources` in `DI.Abstractions`. I'm not sure that it's the best solution, but I don't see another option.