### PR TITLE
Expanded captive dependency check

### DIFF
--- a/src/DI/Properties/Resources.Designer.cs
+++ b/src/DI/Properties/Resources.Designer.cs
@@ -150,6 +150,20 @@ namespace Microsoft.Extensions.DependencyInjection
         internal static string FormatDirectScopedResolvedFromRootException(object p0, object p1)
             => string.Format(CultureInfo.CurrentCulture, GetString("DirectScopedResolvedFromRootException"), p0, p1);
 
+        /// <summary>
+        /// Cannot consume {2} service '{0}' from {3} '{1}'.
+        /// </summary>
+        internal static string CaptiveDependencyException
+        {
+            get => GetString("CaptiveDependencyException");
+        }
+
+        /// <summary>
+        /// Cannot consume {2} service '{0}' from {3} '{1}'.
+        /// </summary>
+        internal static string FormatCaptiveDependencyException(object p0, object p1, object p2, object p3)
+            => string.Format(CultureInfo.CurrentCulture, GetString("CaptiveDependencyException"), p0, p1, p2, p3);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/DI/Resources.resx
+++ b/src/DI/Resources.resx
@@ -150,4 +150,7 @@
   <data name="DirectScopedResolvedFromRootException" xml:space="preserve">
     <value>Cannot resolve {1} service '{0}' from root provider.</value>
   </data>
+  <data name="CaptiveDependencyException" xml:space="preserve">
+    <value>Cannot consume {2} service '{0}' from {3} '{1}'.</value>
+  </data>
 </root>

--- a/src/DI/ServiceLookup/CallSiteValidator.cs
+++ b/src/DI/ServiceLookup/CallSiteValidator.cs
@@ -43,6 +43,25 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         protected override Type VisitTransient(TransientCallSite transientCallSite, CallSiteValidatorState state)
         {
+            if (state.Singleton != null)
+            {
+                throw new InvalidOperationException(Resources.FormatCaptiveDependencyException(
+                    transientCallSite.ServiceType,
+                    state.Singleton.ServiceType,
+                    nameof(ServiceLifetime.Transient).ToLowerInvariant(),
+                    nameof(ServiceLifetime.Singleton).ToLowerInvariant()
+                    ));
+            }
+
+            if (state.Scoped != null)
+            {
+                throw new InvalidOperationException(Resources.FormatCaptiveDependencyException(
+                    transientCallSite.ServiceType,
+                    state.Singleton.ServiceType,
+                    nameof(ServiceLifetime.Transient).ToLowerInvariant(),
+                    nameof(ServiceLifetime.Scoped).ToLowerInvariant()
+                    ));
+            }
             return VisitCallSite(transientCallSite.ServiceCallSite, state);
         }
 
@@ -88,6 +107,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             {
                 return null;
             }
+
+            state.Scoped = scopedCallSite;
             if (state.Singleton != null)
             {
                 throw new InvalidOperationException(Resources.FormatScopedInSingletonException(
@@ -113,6 +134,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         internal struct CallSiteValidatorState
         {
             public SingletonCallSite Singleton { get; set; }
+
+            public ScopedCallSite Scoped { get; set; }
         }
     }
 }

--- a/test/DI.Tests/ServiceProviderValidationTests.cs
+++ b/test/DI.Tests/ServiceProviderValidationTests.cs
@@ -23,6 +23,35 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         }
 
         [Fact]
+        public void GetService_Throws_WhenTransientIsInjectedIntoSingleton()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton<IFoo, Foo>();
+            serviceCollection.AddTransient<IBar, Bar>();
+            var serviceProvider = serviceCollection.BuildServiceProvider(validateScopes: true);
+
+            // Act + Assert
+            var exception = Assert.Throws<InvalidOperationException>(() => serviceProvider.GetService(typeof(IFoo)));
+            Assert.Equal($"Cannot consume transient service '{typeof(IBar)}' from singleton '{typeof(IFoo)}'.", exception.Message);
+        }
+
+        [Fact]
+        public void GetService_Throws_WhenTransientIsInjectedIntoSingletonThroughScoped()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton<IFoo, Foo>();
+            serviceCollection.AddScoped<IBar, Bar>();
+            serviceCollection.AddTransient<IBaz, Baz>();
+            var serviceProvider = serviceCollection.BuildServiceProvider(validateScopes: true);
+
+            // Act + Assert
+            var exception = Assert.Throws<InvalidOperationException>(() => serviceProvider.GetService(typeof(IFoo)));
+            Assert.Equal($"Cannot consume scoped service '{typeof(IBar)}' from singleton '{typeof(IFoo)}'.", exception.Message);
+        }
+
+        [Fact]
         public void GetService_Throws_WhenScopedIsInjectedIntoSingletonThroughTransient()
         {
             // Arrange
@@ -34,7 +63,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 
             // Act + Assert
             var exception = Assert.Throws<InvalidOperationException>(() => serviceProvider.GetService(typeof(IFoo)));
-            Assert.Equal($"Cannot consume scoped service '{typeof(IBaz)}' from singleton '{typeof(IFoo)}'.", exception.Message);
+            Assert.Equal($"Cannot consume transient service '{typeof(IBar)}' from singleton '{typeof(IFoo)}'.", exception.Message);
         }
 
         [Fact]


### PR DESCRIPTION
Captive dependency checking checked for singletons being dependent upon a scoped dependency. However, depending on a dependency which lifetime is shorter than its parent is not specific to that relation. This PR adds checks for Singleton -> Transient and Scoped -> Transient.