### PR TITLE
ServiceProviderEngineScope._disposables is intended to be lazy

### DIFF
--- a/src/DI/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/DI/ServiceLookup/ServiceProviderEngineScope.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         // For testing only
         internal Action<object> _captureDisposableCallback;
 
-        private List<IDisposable> _disposables = new List<IDisposable>();
+        private List<IDisposable> _disposables;
 
         private bool _disposed;
 
@@ -67,8 +67,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
             if (!ReferenceEquals(this, service))
             {
-                var disposable = service as IDisposable;
-                if (disposable != null)
+                if (service is IDisposable disposable)
                 {
                     lock (ResolvedServices)
                     {


### PR DESCRIPTION
`_disposables` is set in the implicit ctor and is never set to null, so this change just removes the nullchecks on it.

Admittedly the perf benefit is nominal, but it's a safe change, so why not.