### PR TITLE
Continue walking graph even when found first scoped service

### DIFF
--- a/src/DI/ServiceLookup/CallSiteValidator.cs
+++ b/src/DI/ServiceLookup/CallSiteValidator.cs
@@ -96,6 +96,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     nameof(ServiceLifetime.Singleton).ToLowerInvariant()
                     ));
             }
+
+            VisitCallSite(scopedCallSite.ServiceCallSite, state);
             return scopedCallSite.ServiceType;
         }
 

--- a/test/DI.Tests/ServiceProviderValidationTests.cs
+++ b/test/DI.Tests/ServiceProviderValidationTests.cs
@@ -50,6 +50,23 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             // Act + Assert
             var exception = Assert.Throws<InvalidOperationException>(() => serviceProvider.GetService(typeof(IFoo)));
             Assert.Equal($"Cannot consume scoped service '{typeof(IBaz)}' from singleton '{typeof(IBar)}'.", exception.Message);
+        }       
+        
+        [Fact]
+        public void GetService_Throws_WhenScopedIsInjectedIntoSingletonThroughSingletonAndScopedWhileInScope()
+        {
+            // Arrange
+            var serviceCollection = new ServiceCollection();
+            
+            serviceCollection.AddScoped<IFoo, Foo>();
+            serviceCollection.AddSingleton<IBar, Bar2>();
+            serviceCollection.AddScoped<IBaz, Baz>();
+            var serviceProvider = serviceCollection.BuildServiceProvider(validateScopes: true);
+            var scope = serviceProvider.CreateScope();
+
+            // Act + Assert
+            var exception = Assert.Throws<InvalidOperationException>(() => scope.ServiceProvider.GetService(typeof(IFoo)));
+            Assert.Equal($"Cannot consume scoped service '{typeof(IBaz)}' from singleton '{typeof(IBar)}'.", exception.Message);
         }
 
         [Fact]


### PR DESCRIPTION
We stopped walking call site graph as soon as first scoped service was found caused us to skip lifetime issues deeper in the tree.
https://github.com/aspnet/Home/issues/3021