### PR TITLE
Adding support for constrained open generics

### DIFF
--- a/src/DI.Specification.Tests/DependencyInjectionSpecificationTests.cs
+++ b/src/DI.Specification.Tests/DependencyInjectionSpecificationTests.cs
@@ -546,6 +546,31 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
         }
 
         [Fact]
+        public void ConstrainedOpenGenericServicesCanBeResolved()
+        {
+            // Arrange
+            var collection = new TestServiceCollection();
+            collection.AddTransient(typeof(IFakeOpenGenericService<>), typeof(FakeOpenGenericService<>));
+            collection.AddTransient(typeof(IFakeOpenGenericService<>), typeof(ConstrainedFakeOpenGenericService<>));
+            var poco = new PocoClass();
+            collection.AddSingleton(poco);
+            collection.AddSingleton<IFakeSingletonService, FakeService>();
+            var provider = CreateServiceProvider(collection);
+
+            // Act
+            var allServices = provider.GetServices<IFakeOpenGenericService<PocoClass>>().ToList();
+            var constrainedServices = provider.GetServices<IFakeOpenGenericService<IFakeSingletonService>>().ToList();
+            var singletonService = provider.GetService<IFakeSingletonService>();
+
+            // Assert
+            Assert.Equal(2, allServices.Count);
+            Assert.Same(poco, allServices[0].Value);
+            Assert.Same(poco, allServices[1].Value);
+            Assert.Equal(1, constrainedServices.Count);
+            Assert.Same(singletonService, constrainedServices[0].Value);
+        }
+
+        [Fact]
         public void ClosedServicesPreferredOverOpenGenericServices()
         {
             // Arrange

--- a/src/DI.Specification.Tests/Fakes/ConstrainedFakeOpenGenericService.cs
+++ b/src/DI.Specification.Tests/Fakes/ConstrainedFakeOpenGenericService.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
+{
+    public class ConstrainedFakeOpenGenericService<TVal> : IFakeOpenGenericService<TVal>
+        where TVal : PocoClass
+    {
+        public ConstrainedFakeOpenGenericService(TVal value)
+        {
+            Value = value;
+        }
+
+        public TVal Value { get; }
+    }
+}

--- a/src/DI/ServiceLookup/CallSiteFactory.cs
+++ b/src/DI/ServiceLookup/CallSiteFactory.cs
@@ -294,7 +294,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     {
                         genericType = typeDefinition.MakeGenericType(genericArguments);
                     }
-                    catch (Exception)
+					catch (ArgumentException)
                     {
                         return false;
                     }

--- a/src/DI/ServiceLookup/CallSiteFactory.cs
+++ b/src/DI/ServiceLookup/CallSiteFactory.cs
@@ -295,7 +295,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     {
                         genericType = typeDefinition.MakeGenericType(genericArguments);
                     }
-					catch (ArgumentException)
+                    catch (ArgumentException)
                     {
                         return false;
                     }

--- a/src/DI/ServiceLookup/CallSiteFactory.cs
+++ b/src/DI/ServiceLookup/CallSiteFactory.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 var specialConstraints = argumentDefinitionTypeInfo.GenericParameterAttributes;
 
                 if ((specialConstraints & GenericParameterAttributes.DefaultConstructorConstraint)
-                    != GenericParameterAttributes.None)
+				    == GenericParameterAttributes.DefaultConstructorConstraint)
                 {
                     if (!parameterTypeInfo.IsValueType && parameterTypeInfo.DeclaredConstructors.All(c => c.GetParameters().Length != 0))
                     {
@@ -237,7 +237,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 }
 
                 if ((specialConstraints & GenericParameterAttributes.ReferenceTypeConstraint)
-                    != GenericParameterAttributes.None)
+				    == GenericParameterAttributes.ReferenceTypeConstraint)
                 {
                     if (parameterTypeInfo.IsValueType)
                     {
@@ -246,7 +246,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 }
 
                 if ((specialConstraints & GenericParameterAttributes.NotNullableValueTypeConstraint)
-                    != GenericParameterAttributes.None)
+				    == GenericParameterAttributes.NotNullableValueTypeConstraint)
                 {
                     if (!parameterTypeInfo.IsValueType ||
                         (parameterTypeInfo.IsGenericType && IsGenericTypeDefinedBy(parameter, typeof(Nullable<>))))
@@ -261,8 +261,9 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         private static bool IsGenericTypeDefinedBy(Type type, Type openGeneric)
         {
-            return !type.GetTypeInfo().ContainsGenericParameters
-                       && type.GetTypeInfo().IsGenericType
+			var typeInfo = type.GetTypeInfo();
+			return !typeInfo.ContainsGenericParameters
+                       && typeInfo.IsGenericType
                        && type.GetGenericTypeDefinition() == openGeneric;
         }
 

--- a/src/DI/ServiceLookup/CallSiteFactory.cs
+++ b/src/DI/ServiceLookup/CallSiteFactory.cs
@@ -197,7 +197,16 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             {
                 Debug.Assert(descriptor.ImplementationType != null, "descriptor.ImplementationType != null");
 
-                var closedType = descriptor.ImplementationType.MakeGenericType(serviceType.GenericTypeArguments);
+                Type closedType;
+                try
+                {
+                    closedType = descriptor.ImplementationType.MakeGenericType(serviceType.GenericTypeArguments);
+                }
+                catch
+                {
+                    // This is the only way to reliably test generic constraints. See https://stackoverflow.com/questions/4864496/checking-if-an-object-meets-a-generic-parameter-constraint/4864565#4864565
+                    return null;
+                }
                 var constructorCallSite = CreateConstructorCallSite(serviceType, closedType, callSiteChain);
 
                 return ApplyLifetime(constructorCallSite, Tuple.Create(descriptor, serviceType), descriptor.Lifetime);

--- a/src/DI/ServiceLookup/CallSiteFactory.cs
+++ b/src/DI/ServiceLookup/CallSiteFactory.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 if ((specialConstraints & GenericParameterAttributes.DefaultConstructorConstraint)
 				    == GenericParameterAttributes.DefaultConstructorConstraint)
                 {
-                    if (!parameterTypeInfo.IsValueType && parameterTypeInfo.DeclaredConstructors.All(c => c.GetParameters().Length != 0))
+                    if (!parameterTypeInfo.IsValueType && parameterTypeInfo.DeclaredConstructors.Where(c => c.IsPublic).All(c => c.GetParameters().Length != 0))
                     {
                         return false;
                     }

--- a/src/DI/ServiceLookup/CallSiteFactory.cs
+++ b/src/DI/ServiceLookup/CallSiteFactory.cs
@@ -289,26 +289,27 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 var typeDefinition = constraint.GetGenericTypeDefinition();
                 if (typeDefinition.GetTypeInfo().GenericTypeParameters.Length == genericArguments.Length)
                 {
+                    Type genericType;
                     try
                     {
-                        var genericType = typeDefinition.MakeGenericType(genericArguments);
-                        var constraintArguments = constraint.GetTypeInfo().GenericTypeArguments;
-
-                        for (var i = 0; i < constraintArguments.Length; i++)
-                        {
-                            var constraintArgument = constraintArguments[i].GetTypeInfo();
-                            if (!constraintArgument.IsGenericParameter && !constraintArgument.IsAssignableFrom(genericArguments[i].GetTypeInfo()))
-                            {
-                                return false;
-                            }
-                        }
-
-                        return genericType == parameter;
+                        genericType = typeDefinition.MakeGenericType(genericArguments);
                     }
                     catch (Exception)
                     {
                         return false;
                     }
+                    var constraintArguments = constraint.GetTypeInfo().GenericTypeArguments;
+
+                    for (var i = 0; i < constraintArguments.Length; i++)
+                    {
+                        var constraintArgument = constraintArguments[i].GetTypeInfo();
+                        if (!constraintArgument.IsGenericParameter && !constraintArgument.IsAssignableFrom(genericArguments[i].GetTypeInfo()))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return genericType == parameter;
                 }
             }
 

--- a/src/DI/ServiceLookup/CallSiteFactory.cs
+++ b/src/DI/ServiceLookup/CallSiteFactory.cs
@@ -281,7 +281,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                        .Any(p => ParameterEqualsConstraint(p, constraint));
         }
 
-        //[SuppressMessage("Microsoft.Design", "CA1031", Justification = "Implementing a real TryMakeGenericType is not worth the effort.")]
         private static bool ParameterEqualsConstraint(Type parameter, Type constraint)
         {
             var genericArguments = parameter.GenericTypeArguments;

--- a/src/Microsoft.Extensions.DependencyInjection.Specification.Tests/Fakes/ConstrainedFakeOpenGenericService.cs
+++ b/src/Microsoft.Extensions.DependencyInjection.Specification.Tests/Fakes/ConstrainedFakeOpenGenericService.cs
@@ -1,0 +1,16 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Extensions.DependencyInjection.Specification.Fakes
+{
+    public class ConstrainedFakeOpenGenericService<TVal> : IFakeOpenGenericService<TVal> 
+        where TVal : PocoClass
+    {
+        public ConstrainedFakeOpenGenericService(TVal value)
+        {
+            Value = value;
+        }
+
+        public TVal Value { get; }
+    }
+}

--- a/test/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
+++ b/test/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
@@ -109,6 +109,23 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             Assert.IsType<CreateInstanceCallSite>(transientCall.ServiceCallSite);
         }
 
+        [Fact]
+        public void CreateCallSite_ReturnsNull_IfClosedTypeDoesNotSatisfyStructGenericConstraint()
+        {
+            // Arrange
+            var serviceType = typeof(IFakeOpenGenericService<>);
+            var implementationType = typeof(TypeWithStructConstraint<>);
+            var descriptor = new ServiceDescriptor(serviceType, implementationType, ServiceLifetime.Transient);
+            var callSiteFactory = GetCallSiteFactory(descriptor);
+
+            // Act
+            var nonMatchingType = typeof(IFakeOpenGenericService<object>);
+            var nonMatchingCallSite = callSiteFactory(nonMatchingType);
+
+            // Assert
+            Assert.Null(nonMatchingCallSite);
+        }
+
         public static TheoryData CreateCallSite_PicksConstructorWithTheMostNumberOfResolvedParametersData =>
             new TheoryData<Type, Func<Type, object>, Type[]>
             {

--- a/test/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
+++ b/test/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
@@ -126,6 +126,23 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             Assert.Null(nonMatchingCallSite);
         }
 
+        [Fact]
+        public void CreateCallSite_ReturnsNull_IfClosedTypeDoesNotSatisfyClassGenericConstraint()
+        {
+            // Arrange
+            var serviceType = typeof(IFakeOpenGenericService<>);
+            var implementationType = typeof(TypeWithClassConstraint<>);
+            var descriptor = new ServiceDescriptor(serviceType, implementationType, ServiceLifetime.Transient);
+            var callSiteFactory = GetCallSiteFactory(descriptor);
+
+            // Act
+            var nonMatchingType = typeof(IFakeOpenGenericService<int>);
+            var nonMatchingCallSite = callSiteFactory(nonMatchingType);
+
+            // Assert
+            Assert.Null(nonMatchingCallSite);
+        }
+
         public static TheoryData CreateCallSite_PicksConstructorWithTheMostNumberOfResolvedParametersData =>
             new TheoryData<Type, Func<Type, object>, Type[]>
             {

--- a/test/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
+++ b/test/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
@@ -143,6 +143,40 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             Assert.Null(nonMatchingCallSite);
         }
 
+        [Fact]
+        public void CreateCallSite_ReturnsNull_IfClosedTypeDoesNotSatisfyNewGenericConstraint()
+        {
+            // Arrange
+            var serviceType = typeof(IFakeOpenGenericService<>);
+            var implementationType = typeof(TypeWithNewConstraint<>);
+            var descriptor = new ServiceDescriptor(serviceType, implementationType, ServiceLifetime.Transient);
+            var callSiteFactory = GetCallSiteFactory(descriptor);
+
+            // Act
+            var nonMatchingType = typeof(IFakeOpenGenericService<TypeWithNoPublicConstructors>);
+            var nonMatchingCallSite = callSiteFactory(nonMatchingType);
+
+            // Assert
+            Assert.Null(nonMatchingCallSite);
+        }
+
+        [Fact]
+        public void CreateCallSite_ReturnsNull_IfClosedTypeDoesNotSatisfyInterfaceGenericConstraint()
+        {
+            // Arrange
+            var serviceType = typeof(IFakeOpenGenericService<>);
+            var implementationType = typeof(TypeWithInterfaceConstraint<>);
+            var descriptor = new ServiceDescriptor(serviceType, implementationType, ServiceLifetime.Transient);
+            var callSiteFactory = GetCallSiteFactory(descriptor);
+
+            // Act
+            var nonMatchingType = typeof(IFakeOpenGenericService<int>);
+            var nonMatchingCallSite = callSiteFactory(nonMatchingType);
+
+            // Assert
+            Assert.Null(nonMatchingCallSite);
+        }
+
         public static TheoryData CreateCallSite_PicksConstructorWithTheMostNumberOfResolvedParametersData =>
             new TheoryData<Type, Func<Type, object>, Type[]>
             {

--- a/test/DI.Tests/ServiceLookup/Types/TypeWithClassConstraint.cs
+++ b/test/DI.Tests/ServiceLookup/Types/TypeWithClassConstraint.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
+
+namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
+{
+    public class TypeWithClassConstraint<T> : IFakeOpenGenericService<T>
+        where T : class
+    {
+        public T Value { get; } = default;
+    }
+}

--- a/test/DI.Tests/ServiceLookup/Types/TypeWithInterfaceConstraint.cs
+++ b/test/DI.Tests/ServiceLookup/Types/TypeWithInterfaceConstraint.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections;
+using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
+
+namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
+{
+    public class TypeWithInterfaceConstraint<T> : IFakeOpenGenericService<T>
+        where T : IEnumerable
+    {
+        public T Value { get; set; }
+    }
+}

--- a/test/DI.Tests/ServiceLookup/Types/TypeWithNewConstraint.cs
+++ b/test/DI.Tests/ServiceLookup/Types/TypeWithNewConstraint.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
+
+namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
+{
+    public class TypeWithNewConstraint<T> : IFakeOpenGenericService<T>
+        where T : new()
+    {
+        public T Value { get; } = default;
+    }
+}

--- a/test/DI.Tests/ServiceLookup/Types/TypeWithStructConstraint.cs
+++ b/test/DI.Tests/ServiceLookup/Types/TypeWithStructConstraint.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
+
+namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
+{
+    public class TypeWithStructConstraint<T> : IFakeOpenGenericService<T>
+        where T : struct
+    {
+        public T Value { get; } = default;
+    }
+}


### PR DESCRIPTION
(again)

See #471 for details. Figured I'd give this another shot.

The general scenario is:

Suppose I have some interface, `IRepository<T>`. This interface allows me to save an entity to a database, perhaps wrapping EFCore `DbContext`. As part of saving, I want to validate so I have `IValidator<T>`.

The implementation `DbContextRepository<T>` uses an enumerable of  `IValidator<T>` to validate:

```c#
class DbContextRepository<T> {
    public DbContextRepository(
        DbContext db, 
        IEnumerable<IValidator<T>> validators) {
        // etc
    }
}
```

I want to be able to support:

```c#
class IFooValidator<T> : IValidator<T> where T : IFoo { }
```

instead of 

```c#
class IFooValidator : IValidator<IFoo> {}
```

For the reasons in #471.

In case anything has changed, just wanted to throw this out there. I modified the approach to do what Autofac does, which is actually check the constraints if they exist (instead of the previous try-catch-swallow approach).