### PR TITLE
Make lifetime a callsite property and add stackguards

### DIFF
--- a/src/DI/DI.csproj
+++ b/src/DI/DI.csproj
@@ -10,7 +10,7 @@
     <DefineConstants Condition="'$(ILEmitBackend)' == 'True'">$(DefineConstants);IL_EMIT</DefineConstants>
 
     <!-- Debug IL generation -->
-    <ILEmitBackendSaveAssemblies>True</ILEmitBackendSaveAssemblies>
+    <ILEmitBackendSaveAssemblies>False</ILEmitBackendSaveAssemblies>
     <DefineConstants Condition="'$(ILEmitBackendSaveAssemblies)' == 'True'">$(DefineConstants);SAVE_ASSEMBLIES</DefineConstants>
   </PropertyGroup>
 

--- a/src/DI/DI.csproj
+++ b/src/DI/DI.csproj
@@ -10,7 +10,7 @@
     <DefineConstants Condition="'$(ILEmitBackend)' == 'True'">$(DefineConstants);IL_EMIT</DefineConstants>
 
     <!-- Debug IL generation -->
-    <ILEmitBackendSaveAssemblies>False</ILEmitBackendSaveAssemblies>
+    <ILEmitBackendSaveAssemblies>True</ILEmitBackendSaveAssemblies>
     <DefineConstants Condition="'$(ILEmitBackendSaveAssemblies)' == 'True'">$(DefineConstants);SAVE_ASSEMBLIES</DefineConstants>
   </PropertyGroup>
 

--- a/src/DI/ServiceLookup/CallSiteFactory.cs
+++ b/src/DI/ServiceLookup/CallSiteFactory.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         public CallSiteFactory(IEnumerable<ServiceDescriptor> descriptors)
         {
-            _stackGuard = new StackGuard(allowConcurrency: true);
+            _stackGuard = new StackGuard();
             _descriptors = descriptors.ToList();
             Populate(descriptors);
         }

--- a/src/DI/ServiceLookup/CallSiteResultCacheLocation.cs
+++ b/src/DI/ServiceLookup/CallSiteResultCacheLocation.cs
@@ -1,9 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
-
+    internal enum CallSiteResultCacheLocation
+    {
+        Root,
+        Scope,
+        Dispose,
+        None
+    }
 }

--- a/src/DI/ServiceLookup/CallSiteRuntimeResolver.cs
+++ b/src/DI/ServiceLookup/CallSiteRuntimeResolver.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         protected override object VisitDisposeCache(ServiceCallSite transientCallSite, ServiceProviderEngineScope scope)
         {
-            return scope.CaptureDisposable(base.VisitDisposeCache(transientCallSite, scope));
+            return scope.CaptureDisposable(VisitCallSiteMain(transientCallSite, scope));
         }
 
         protected override object VisitConstructor(ConstructorCallSite constructorCallSite, ServiceProviderEngineScope scope)
@@ -54,7 +54,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             {
                 if (!scope.ResolvedServices.TryGetValue(scopedCallSite.Cache.Key, out var resolved))
                 {
-                    resolved = base.VisitScopeCache(scopedCallSite, scope);
+                    resolved = VisitCallSiteMain(scopedCallSite, scope);
                     scope.CaptureDisposable(resolved);
                     scope.ResolvedServices.Add(scopedCallSite.Cache.Key, resolved);
                 }

--- a/src/DI/ServiceLookup/CallSiteValidator.cs
+++ b/src/DI/ServiceLookup/CallSiteValidator.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         // Keys are services being resolved via GetService, values - first scoped service in their call site tree
         private readonly ConcurrentDictionary<Type, Type> _scopedServices = new ConcurrentDictionary<Type, Type>();
 
-        public CallSiteValidator() : base(true)
+        public CallSiteValidator() : base()
         {
         }
 

--- a/src/DI/ServiceLookup/CallSiteValidator.cs
+++ b/src/DI/ServiceLookup/CallSiteValidator.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         protected override Type VisitRootCache(ServiceCallSite singletonCallSite, CallSiteValidatorState state)
         {
             state.Singleton = singletonCallSite;
-            return base.VisitRootCache(singletonCallSite, state);
+            return VisitCallSiteMain(singletonCallSite, state);
         }
 
         protected override Type VisitScopeCache(ServiceCallSite scopedCallSite, CallSiteValidatorState state)
@@ -92,7 +92,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     ));
             }
 
-            base.VisitScopeCache(scopedCallSite, state);
+            VisitCallSiteMain(scopedCallSite, state);
             return scopedCallSite.ServiceType;
         }
 

--- a/src/DI/ServiceLookup/CallSiteValidator.cs
+++ b/src/DI/ServiceLookup/CallSiteValidator.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         // Keys are services being resolved via GetService, values - first scoped service in their call site tree
         private readonly ConcurrentDictionary<Type, Type> _scopedServices = new ConcurrentDictionary<Type, Type>();
 
-        public void ValidateCallSite(IServiceCallSite callSite)
+        public void ValidateCallSite(ServiceCallSite callSite)
         {
             var scoped = VisitCallSite(callSite, default);
             if (scoped != null)
@@ -69,13 +69,13 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             return result;
         }
 
-        protected override Type VisitSingleton(IServiceCallSite singletonCallSite, CallSiteValidatorState state)
+        protected override Type VisitRootCache(ServiceCallSite singletonCallSite, CallSiteValidatorState state)
         {
             state.Singleton = singletonCallSite;
-            return base.VisitSingleton(singletonCallSite, state);
+            return base.VisitRootCache(singletonCallSite, state);
         }
 
-        protected override Type VisitScoped(IServiceCallSite scopedCallSite, CallSiteValidatorState state)
+        protected override Type VisitScopeCache(ServiceCallSite scopedCallSite, CallSiteValidatorState state)
         {
             // We are fine with having ServiceScopeService requested by singletons
             if (scopedCallSite is ServiceScopeFactoryCallSite)
@@ -92,7 +92,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     ));
             }
 
-            base.VisitScoped(scopedCallSite, state);
+            base.VisitScopeCache(scopedCallSite, state);
             return scopedCallSite.ServiceType;
         }
 
@@ -106,7 +106,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         internal struct CallSiteValidatorState
         {
-            public IServiceCallSite Singleton { get; set; }
+            public ServiceCallSite Singleton { get; set; }
         }
     }
 }

--- a/src/DI/ServiceLookup/CallSiteValidator.cs
+++ b/src/DI/ServiceLookup/CallSiteValidator.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         // Keys are services being resolved via GetService, values - first scoped service in their call site tree
         private readonly ConcurrentDictionary<Type, Type> _scopedServices = new ConcurrentDictionary<Type, Type>();
 
-        public CallSiteValidator(bool allowConcurrency) : base(true)
+        public CallSiteValidator() : base(true)
         {
         }
 

--- a/src/DI/ServiceLookup/CallSiteValidator.cs
+++ b/src/DI/ServiceLookup/CallSiteValidator.cs
@@ -11,10 +11,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         // Keys are services being resolved via GetService, values - first scoped service in their call site tree
         private readonly ConcurrentDictionary<Type, Type> _scopedServices = new ConcurrentDictionary<Type, Type>();
 
-        public CallSiteValidator() : base()
-        {
-        }
-
         public void ValidateCallSite(ServiceCallSite callSite)
         {
             var scoped = VisitCallSite(callSite, default);

--- a/src/DI/ServiceLookup/CallSiteValidator.cs
+++ b/src/DI/ServiceLookup/CallSiteValidator.cs
@@ -11,6 +11,10 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         // Keys are services being resolved via GetService, values - first scoped service in their call site tree
         private readonly ConcurrentDictionary<Type, Type> _scopedServices = new ConcurrentDictionary<Type, Type>();
 
+        public CallSiteValidator(bool allowConcurrency) : base(true)
+        {
+        }
+
         public void ValidateCallSite(ServiceCallSite callSite)
         {
             var scoped = VisitCallSite(callSite, default);

--- a/src/DI/ServiceLookup/CallSiteValidator.cs
+++ b/src/DI/ServiceLookup/CallSiteValidator.cs
@@ -40,11 +40,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             }
         }
 
-        protected override Type VisitTransient(TransientCallSite transientCallSite, CallSiteValidatorState state)
-        {
-            return VisitCallSite(transientCallSite.ServiceCallSite, state);
-        }
-
         protected override Type VisitConstructor(ConstructorCallSite constructorCallSite, CallSiteValidatorState state)
         {
             Type result = null;
@@ -74,16 +69,16 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             return result;
         }
 
-        protected override Type VisitSingleton(SingletonCallSite singletonCallSite, CallSiteValidatorState state)
+        protected override Type VisitSingleton(IServiceCallSite singletonCallSite, CallSiteValidatorState state)
         {
             state.Singleton = singletonCallSite;
-            return VisitCallSite(singletonCallSite.ServiceCallSite, state);
+            return base.VisitSingleton(singletonCallSite, state);
         }
 
-        protected override Type VisitScoped(ScopedCallSite scopedCallSite, CallSiteValidatorState state)
+        protected override Type VisitScoped(IServiceCallSite scopedCallSite, CallSiteValidatorState state)
         {
             // We are fine with having ServiceScopeService requested by singletons
-            if (scopedCallSite.ServiceCallSite is ServiceScopeFactoryCallSite)
+            if (scopedCallSite is ServiceScopeFactoryCallSite)
             {
                 return null;
             }
@@ -97,13 +92,11 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     ));
             }
 
-            VisitCallSite(scopedCallSite.ServiceCallSite, state);
+            base.VisitScoped(scopedCallSite, state);
             return scopedCallSite.ServiceType;
         }
 
         protected override Type VisitConstant(ConstantCallSite constantCallSite, CallSiteValidatorState state) => null;
-
-        protected override Type VisitCreateInstance(CreateInstanceCallSite createInstanceCallSite, CallSiteValidatorState state) => null;
 
         protected override Type VisitServiceProvider(ServiceProviderCallSite serviceProviderCallSite, CallSiteValidatorState state) => null;
 
@@ -113,7 +106,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         internal struct CallSiteValidatorState
         {
-            public SingletonCallSite Singleton { get; set; }
+            public IServiceCallSite Singleton { get; set; }
         }
     }
 }

--- a/src/DI/ServiceLookup/CallSiteVisitor.cs
+++ b/src/DI/ServiceLookup/CallSiteVisitor.cs
@@ -6,6 +6,21 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     {
         protected virtual TResult VisitCallSite(IServiceCallSite callSite, TArgument argument)
         {
+            switch (callSite.Cache.Location)
+            {
+                case CallSiteResultCacheLocation.Root:
+                    return VisitSingleton(callSite, argument);
+                case CallSiteResultCacheLocation.Scope:
+                    return VisitScoped(callSite, argument);
+                case CallSiteResultCacheLocation.None:
+                    return VisitTransient(callSite, argument);
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        protected virtual TResult VisitCallSiteMain(IServiceCallSite callSite, TArgument argument)
+        {
             switch (callSite.Kind)
             {
                 case CallSiteKind.Factory:
@@ -14,16 +29,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                     return VisitIEnumerable((IEnumerableCallSite)callSite, argument);
                 case CallSiteKind.Constructor:
                     return VisitConstructor((ConstructorCallSite)callSite, argument);
-                case CallSiteKind.Transient:
-                    return VisitTransient((TransientCallSite)callSite, argument);
-                case CallSiteKind.Singleton:
-                    return VisitSingleton((SingletonCallSite)callSite, argument);
-                case CallSiteKind.Scope:
-                    return VisitScoped((ScopedCallSite)callSite, argument);
                 case CallSiteKind.Constant:
                     return VisitConstant((ConstantCallSite)callSite, argument);
-                case CallSiteKind.CreateInstance:
-                    return VisitCreateInstance((CreateInstanceCallSite)callSite, argument);
                 case CallSiteKind.ServiceProvider:
                     return VisitServiceProvider((ServiceProviderCallSite)callSite, argument);
                 case CallSiteKind.ServiceScopeFactory:
@@ -33,17 +40,24 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             }
         }
 
-        protected abstract TResult VisitTransient(TransientCallSite transientCallSite, TArgument argument);
+        protected virtual TResult VisitTransient(IServiceCallSite callSite, TArgument argument)
+        {
+            return VisitCallSiteMain(callSite, argument);
+        }
 
         protected abstract TResult VisitConstructor(ConstructorCallSite constructorCallSite, TArgument argument);
 
-        protected abstract TResult VisitSingleton(SingletonCallSite singletonCallSite, TArgument argument);
+        protected virtual TResult VisitSingleton(IServiceCallSite callSite, TArgument argument)
+        {
+            return VisitCallSiteMain(callSite, argument);
+        }
 
-        protected abstract TResult VisitScoped(ScopedCallSite scopedCallSite, TArgument argument);
+        protected virtual TResult VisitScoped(IServiceCallSite callSite, TArgument argument)
+        {
+            return VisitCallSiteMain(callSite, argument);
+        }
 
         protected abstract TResult VisitConstant(ConstantCallSite constantCallSite, TArgument argument);
-
-        protected abstract TResult VisitCreateInstance(CreateInstanceCallSite createInstanceCallSite, TArgument argument);
 
         protected abstract TResult VisitServiceProvider(ServiceProviderCallSite serviceProviderCallSite, TArgument argument);
 

--- a/src/DI/ServiceLookup/CallSiteVisitor.cs
+++ b/src/DI/ServiceLookup/CallSiteVisitor.cs
@@ -7,9 +7,9 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     {
         private readonly StackGuard _stackGuard;
 
-        protected CallSiteVisitor(bool allowConcurrency)
+        protected CallSiteVisitor()
         {
-            _stackGuard = new StackGuard(allowConcurrency);
+            _stackGuard = new StackGuard();
         }
 
         protected virtual TResult VisitCallSite(ServiceCallSite callSite, TArgument argument)

--- a/src/DI/ServiceLookup/CallSiteVisitor.cs
+++ b/src/DI/ServiceLookup/CallSiteVisitor.cs
@@ -4,22 +4,24 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal abstract class CallSiteVisitor<TArgument, TResult>
     {
-        protected virtual TResult VisitCallSite(IServiceCallSite callSite, TArgument argument)
+        protected virtual TResult VisitCallSite(ServiceCallSite callSite, TArgument argument)
         {
             switch (callSite.Cache.Location)
             {
                 case CallSiteResultCacheLocation.Root:
-                    return VisitSingleton(callSite, argument);
+                    return VisitRootCache(callSite, argument);
                 case CallSiteResultCacheLocation.Scope:
-                    return VisitScoped(callSite, argument);
+                    return VisitScopeCache(callSite, argument);
+                case CallSiteResultCacheLocation.Dispose:
+                    return VisitDisposeCache(callSite, argument);
                 case CallSiteResultCacheLocation.None:
-                    return VisitTransient(callSite, argument);
+                    return VisitNoCache(callSite, argument);
                 default:
                     throw new ArgumentOutOfRangeException();
             }
         }
 
-        protected virtual TResult VisitCallSiteMain(IServiceCallSite callSite, TArgument argument)
+        protected virtual TResult VisitCallSiteMain(ServiceCallSite callSite, TArgument argument)
         {
             switch (callSite.Kind)
             {
@@ -40,22 +42,27 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             }
         }
 
-        protected virtual TResult VisitTransient(IServiceCallSite callSite, TArgument argument)
+        protected virtual TResult VisitNoCache(ServiceCallSite callSite, TArgument argument)
+        {
+            return VisitCallSiteMain(callSite, argument);
+        }
+
+        protected virtual TResult VisitDisposeCache(ServiceCallSite callSite, TArgument argument)
+        {
+            return VisitCallSiteMain(callSite, argument);
+        }
+
+        protected virtual TResult VisitRootCache(ServiceCallSite callSite, TArgument argument)
+        {
+            return VisitCallSiteMain(callSite, argument);
+        }
+
+        protected virtual TResult VisitScopeCache(ServiceCallSite callSite, TArgument argument)
         {
             return VisitCallSiteMain(callSite, argument);
         }
 
         protected abstract TResult VisitConstructor(ConstructorCallSite constructorCallSite, TArgument argument);
-
-        protected virtual TResult VisitSingleton(IServiceCallSite callSite, TArgument argument)
-        {
-            return VisitCallSiteMain(callSite, argument);
-        }
-
-        protected virtual TResult VisitScoped(IServiceCallSite callSite, TArgument argument)
-        {
-            return VisitCallSiteMain(callSite, argument);
-        }
 
         protected abstract TResult VisitConstant(ConstantCallSite constantCallSite, TArgument argument);
 

--- a/src/DI/ServiceLookup/CallSiteVisitor.cs
+++ b/src/DI/ServiceLookup/CallSiteVisitor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
@@ -6,6 +7,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     {
         protected virtual TResult VisitCallSite(ServiceCallSite callSite, TArgument argument)
         {
+            RuntimeHelpers.EnsureSufficientExecutionStack();
             switch (callSite.Cache.Location)
             {
                 case CallSiteResultCacheLocation.Root:

--- a/src/DI/ServiceLookup/CompiledServiceProviderEngine.cs
+++ b/src/DI/ServiceLookup/CompiledServiceProviderEngine.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             ExpressionResolverBuilder = new ExpressionResolverBuilder(RuntimeResolver, this, Root);
         }
 
-        protected override Func<ServiceProviderEngineScope, object> RealizeService(IServiceCallSite callSite)
+        protected override Func<ServiceProviderEngineScope, object> RealizeService(ServiceCallSite callSite)
         {
             var realizedService = ExpressionResolverBuilder.Build(callSite);
             RealizedServices[callSite.ServiceType] = realizedService;

--- a/src/DI/ServiceLookup/ConstantCallSite.cs
+++ b/src/DI/ServiceLookup/ConstantCallSite.cs
@@ -5,11 +5,11 @@ using System;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
-    internal class ConstantCallSite : IServiceCallSite
+    internal class ConstantCallSite : ServiceCallSite
     {
         internal object DefaultValue { get; }
 
-        public ConstantCallSite(Type serviceType, object defaultValue): base(new ResultCache(ServiceLifetime.Singleton, null))
+        public ConstantCallSite(Type serviceType, object defaultValue): base(ResultCache.None)
         {
             DefaultValue = defaultValue;
         }

--- a/src/DI/ServiceLookup/ConstantCallSite.cs
+++ b/src/DI/ServiceLookup/ConstantCallSite.cs
@@ -9,13 +9,13 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     {
         internal object DefaultValue { get; }
 
-        public ConstantCallSite(Type serviceType, object defaultValue)
+        public ConstantCallSite(Type serviceType, object defaultValue): base(new ResultCache(ServiceLifetime.Singleton, null))
         {
             DefaultValue = defaultValue;
         }
 
-        public Type ServiceType => DefaultValue.GetType();
-        public Type ImplementationType => DefaultValue.GetType();
-        public CallSiteKind Kind { get; } = CallSiteKind.Constant;
+        public override Type ServiceType => DefaultValue.GetType();
+        public override Type ImplementationType => DefaultValue.GetType();
+        public override CallSiteKind Kind { get; } = CallSiteKind.Constant;
     }
 }

--- a/src/DI/ServiceLookup/ConstructorCallSite.cs
+++ b/src/DI/ServiceLookup/ConstructorCallSite.cs
@@ -6,16 +6,16 @@ using System.Reflection;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
-    internal class ConstructorCallSite : IServiceCallSite
+    internal class ConstructorCallSite : ServiceCallSite
     {
         internal ConstructorInfo ConstructorInfo { get; }
-        internal IServiceCallSite[] ParameterCallSites { get; }
+        internal ServiceCallSite[] ParameterCallSites { get; }
 
-        public ConstructorCallSite(ResultCache cache, Type serviceType, ConstructorInfo constructorInfo) : this(cache, serviceType, constructorInfo, Array.Empty<IServiceCallSite>())
+        public ConstructorCallSite(ResultCache cache, Type serviceType, ConstructorInfo constructorInfo) : this(cache, serviceType, constructorInfo, Array.Empty<ServiceCallSite>())
         {
         }
 
-        public ConstructorCallSite(ResultCache cache, Type serviceType, ConstructorInfo constructorInfo, IServiceCallSite[] parameterCallSites) : base(cache)
+        public ConstructorCallSite(ResultCache cache, Type serviceType, ConstructorInfo constructorInfo, ServiceCallSite[] parameterCallSites) : base(cache)
         {
             ServiceType = serviceType;
             ConstructorInfo = constructorInfo;

--- a/src/DI/ServiceLookup/ConstructorCallSite.cs
+++ b/src/DI/ServiceLookup/ConstructorCallSite.cs
@@ -11,16 +11,20 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         internal ConstructorInfo ConstructorInfo { get; }
         internal IServiceCallSite[] ParameterCallSites { get; }
 
-        public ConstructorCallSite(Type serviceType, ConstructorInfo constructorInfo, IServiceCallSite[] parameterCallSites)
+        public ConstructorCallSite(ResultCache cache, Type serviceType, ConstructorInfo constructorInfo) : this(cache, serviceType, constructorInfo, Array.Empty<IServiceCallSite>())
+        {
+        }
+
+        public ConstructorCallSite(ResultCache cache, Type serviceType, ConstructorInfo constructorInfo, IServiceCallSite[] parameterCallSites) : base(cache)
         {
             ServiceType = serviceType;
             ConstructorInfo = constructorInfo;
             ParameterCallSites = parameterCallSites;
         }
 
-        public Type ServiceType { get; }
+        public override Type ServiceType { get; }
 
-        public Type ImplementationType => ConstructorInfo.DeclaringType;
-        public CallSiteKind Kind { get; } = CallSiteKind.Constructor;
+        public override Type ImplementationType => ConstructorInfo.DeclaringType;
+        public override CallSiteKind Kind { get; } = CallSiteKind.Constructor;
     }
 }

--- a/src/DI/ServiceLookup/CreateInstanceCallSite.cs
+++ b/src/DI/ServiceLookup/CreateInstanceCallSite.cs
@@ -6,17 +6,4 @@ using System.Runtime.ExceptionServices;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
-    internal class CreateInstanceCallSite : IServiceCallSite
-    {
-        public Type ServiceType { get; }
-
-        public Type ImplementationType { get; }
-        public CallSiteKind Kind { get; } = CallSiteKind.CreateInstance;
-
-        public CreateInstanceCallSite(Type serviceType, Type implementationType)
-        {
-            ServiceType = serviceType;
-            ImplementationType = implementationType;
-        }
-    }
 }

--- a/src/DI/ServiceLookup/DynamicServiceProviderEngine.cs
+++ b/src/DI/ServiceLookup/DynamicServiceProviderEngine.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
         }
 
-        protected override Func<ServiceProviderEngineScope, object> RealizeService(IServiceCallSite callSite)
+        protected override Func<ServiceProviderEngineScope, object> RealizeService(ServiceCallSite callSite)
         {
             var callCount = 0;
             return scope =>

--- a/src/DI/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
+++ b/src/DI/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         private readonly ServiceProviderEngineScope _rootScope;
 
         public ExpressionResolverBuilder(CallSiteRuntimeResolver runtimeResolver, IServiceScopeFactory serviceScopeFactory, ServiceProviderEngineScope rootScope):
-            base(allowConcurrency: true)
+            base()
         {
             if (runtimeResolver == null)
             {

--- a/src/DI/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
+++ b/src/DI/ServiceLookup/Expressions/ExpressionResolverBuilder.cs
@@ -41,7 +41,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         private readonly ServiceProviderEngineScope _rootScope;
 
-        public ExpressionResolverBuilder(CallSiteRuntimeResolver runtimeResolver, IServiceScopeFactory serviceScopeFactory, ServiceProviderEngineScope rootScope)
+        public ExpressionResolverBuilder(CallSiteRuntimeResolver runtimeResolver, IServiceScopeFactory serviceScopeFactory, ServiceProviderEngineScope rootScope):
+            base(allowConcurrency: true)
         {
             if (runtimeResolver == null)
             {

--- a/src/DI/ServiceLookup/Expressions/ExpressionsServiceProviderEngine.cs
+++ b/src/DI/ServiceLookup/Expressions/ExpressionsServiceProviderEngine.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             _expressionResolverBuilder = new ExpressionResolverBuilder(RuntimeResolver, this, Root);
         }
 
-        protected override Func<ServiceProviderEngineScope, object> RealizeService(IServiceCallSite callSite)
+        protected override Func<ServiceProviderEngineScope, object> RealizeService(ServiceCallSite callSite)
         {
             var realizedService = _expressionResolverBuilder.Build(callSite);
             RealizedServices[callSite.ServiceType] = realizedService;

--- a/src/DI/ServiceLookup/FactoryCallSite.cs
+++ b/src/DI/ServiceLookup/FactoryCallSite.cs
@@ -9,15 +9,15 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     {
         public Func<IServiceProvider, object> Factory { get; }
 
-        public FactoryCallSite(Type serviceType, Func<IServiceProvider, object> factory)
+        public FactoryCallSite(ResultCache cache, Type serviceType, Func<IServiceProvider, object> factory) : base(cache)
         {
             Factory = factory;
             ServiceType = serviceType;
         }
 
-        public Type ServiceType { get; }
-        public Type ImplementationType => null;
+        public override Type ServiceType { get; }
+        public override Type ImplementationType => null;
 
-        public CallSiteKind Kind { get; } = CallSiteKind.Factory;
+        public override CallSiteKind Kind { get; } = CallSiteKind.Factory;
     }
 }

--- a/src/DI/ServiceLookup/FactoryCallSite.cs
+++ b/src/DI/ServiceLookup/FactoryCallSite.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
-    internal class FactoryCallSite : IServiceCallSite
+    internal class FactoryCallSite : ServiceCallSite
     {
         public Func<IServiceProvider, object> Factory { get; }
 

--- a/src/DI/ServiceLookup/IEnumerableCallSite.cs
+++ b/src/DI/ServiceLookup/IEnumerableCallSite.cs
@@ -6,12 +6,12 @@ using System.Collections.Generic;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
-    internal class IEnumerableCallSite : IServiceCallSite
+    internal class IEnumerableCallSite : ServiceCallSite
     {
         internal Type ItemType { get; }
-        internal IServiceCallSite[] ServiceCallSites { get; }
+        internal ServiceCallSite[] ServiceCallSites { get; }
 
-        public IEnumerableCallSite(Type itemType, IServiceCallSite[] serviceCallSites) : base(new ResultCache(ServiceLifetime.Transient, null))
+        public IEnumerableCallSite(Type itemType, ServiceCallSite[] serviceCallSites) : base(ResultCache.None)
         {
             ItemType = itemType;
             ServiceCallSites = serviceCallSites;

--- a/src/DI/ServiceLookup/IEnumerableCallSite.cs
+++ b/src/DI/ServiceLookup/IEnumerableCallSite.cs
@@ -11,14 +11,14 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         internal Type ItemType { get; }
         internal IServiceCallSite[] ServiceCallSites { get; }
 
-        public IEnumerableCallSite(Type itemType, IServiceCallSite[] serviceCallSites)
+        public IEnumerableCallSite(Type itemType, IServiceCallSite[] serviceCallSites) : base(new ResultCache(ServiceLifetime.Transient, null))
         {
             ItemType = itemType;
             ServiceCallSites = serviceCallSites;
         }
 
-        public Type ServiceType => typeof(IEnumerable<>).MakeGenericType(ItemType);
-        public Type ImplementationType  => ItemType.MakeArrayType();
-        public CallSiteKind Kind { get; } = CallSiteKind.IEnumerable;
+        public override Type ServiceType => typeof(IEnumerable<>).MakeGenericType(ItemType);
+        public override Type ImplementationType  => ItemType.MakeArrayType();
+        public override CallSiteKind Kind { get; } = CallSiteKind.IEnumerable;
     }
 }

--- a/src/DI/ServiceLookup/ILEmit/ILEmitCallSiteAnalyzer.cs
+++ b/src/DI/ServiceLookup/ILEmit/ILEmitCallSiteAnalyzer.cs
@@ -18,6 +18,10 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         private const int FactoryILSize = 16;
 
+        public ILEmitCallSiteAnalyzer() : base(allowConcurrency: true)
+        {
+        }
+
         internal static ILEmitCallSiteAnalyzer Instance { get; } = new ILEmitCallSiteAnalyzer();
 
         protected override ILEmitCallSiteAnalysisResult VisitDisposeCache(ServiceCallSite transientCallSite, object argument) => VisitCallSiteMain(transientCallSite, argument);

--- a/src/DI/ServiceLookup/ILEmit/ILEmitCallSiteAnalyzer.cs
+++ b/src/DI/ServiceLookup/ILEmit/ILEmitCallSiteAnalyzer.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         private const int FactoryILSize = 16;
 
-        public ILEmitCallSiteAnalyzer() : base(allowConcurrency: true)
+        public ILEmitCallSiteAnalyzer() : base()
         {
         }
 

--- a/src/DI/ServiceLookup/ILEmit/ILEmitCallSiteAnalyzer.cs
+++ b/src/DI/ServiceLookup/ILEmit/ILEmitCallSiteAnalyzer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         internal static ILEmitCallSiteAnalyzer Instance { get; } = new ILEmitCallSiteAnalyzer();
 
-        protected override ILEmitCallSiteAnalysisResult VisitTransient(TransientCallSite transientCallSite, object argument) => VisitCallSite(transientCallSite.ServiceCallSite, argument);
+        protected override ILEmitCallSiteAnalysisResult VisitTransient(IServiceCallSite transientCallSite, object argument) => base.VisitTransient(transientCallSite, argument);
 
         protected override ILEmitCallSiteAnalysisResult VisitConstructor(ConstructorCallSite constructorCallSite, object argument)
         {
@@ -32,16 +32,14 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             return result;
         }
 
-        protected override ILEmitCallSiteAnalysisResult VisitSingleton(SingletonCallSite singletonCallSite, object argument) => VisitCallSite(singletonCallSite.ServiceCallSite, argument);
+        protected override ILEmitCallSiteAnalysisResult VisitSingleton(IServiceCallSite singletonCallSite, object argument) => base.VisitSingleton(singletonCallSite, argument);
 
-        protected override ILEmitCallSiteAnalysisResult VisitScoped(ScopedCallSite scopedCallSite, object argument)
+        protected override ILEmitCallSiteAnalysisResult VisitScoped(IServiceCallSite scopedCallSite, object argument)
         {
-            return new ILEmitCallSiteAnalysisResult(ScopedILSize, hasScope: true).Add(VisitCallSite(scopedCallSite.ServiceCallSite, argument));
+            return new ILEmitCallSiteAnalysisResult(ScopedILSize, hasScope: true).Add(base.VisitScoped(scopedCallSite, argument));
         }
 
         protected override ILEmitCallSiteAnalysisResult VisitConstant(ConstantCallSite constantCallSite, object argument) => new ILEmitCallSiteAnalysisResult(ConstantILSize);
-
-        protected override ILEmitCallSiteAnalysisResult VisitCreateInstance(CreateInstanceCallSite createInstanceCallSite, object argument) => new ILEmitCallSiteAnalysisResult(ConstructorILSize);
 
         protected override ILEmitCallSiteAnalysisResult VisitServiceProvider(ServiceProviderCallSite serviceProviderCallSite, object argument) => new ILEmitCallSiteAnalysisResult(ServiceProviderSize);
 

--- a/src/DI/ServiceLookup/ILEmit/ILEmitCallSiteAnalyzer.cs
+++ b/src/DI/ServiceLookup/ILEmit/ILEmitCallSiteAnalyzer.cs
@@ -18,10 +18,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         private const int FactoryILSize = 16;
 
-        public ILEmitCallSiteAnalyzer() : base()
-        {
-        }
-
         internal static ILEmitCallSiteAnalyzer Instance { get; } = new ILEmitCallSiteAnalyzer();
 
         protected override ILEmitCallSiteAnalysisResult VisitDisposeCache(ServiceCallSite transientCallSite, object argument) => VisitCallSiteMain(transientCallSite, argument);

--- a/src/DI/ServiceLookup/ILEmit/ILEmitCallSiteAnalyzer.cs
+++ b/src/DI/ServiceLookup/ILEmit/ILEmitCallSiteAnalyzer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         internal static ILEmitCallSiteAnalyzer Instance { get; } = new ILEmitCallSiteAnalyzer();
 
-        protected override ILEmitCallSiteAnalysisResult VisitDisposeCache(ServiceCallSite transientCallSite, object argument) => base.VisitDisposeCache(transientCallSite, argument);
+        protected override ILEmitCallSiteAnalysisResult VisitDisposeCache(ServiceCallSite transientCallSite, object argument) => VisitCallSiteMain(transientCallSite, argument);
 
         protected override ILEmitCallSiteAnalysisResult VisitConstructor(ConstructorCallSite constructorCallSite, object argument)
         {
@@ -32,11 +32,11 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             return result;
         }
 
-        protected override ILEmitCallSiteAnalysisResult VisitRootCache(ServiceCallSite singletonCallSite, object argument) => base.VisitRootCache(singletonCallSite, argument);
+        protected override ILEmitCallSiteAnalysisResult VisitRootCache(ServiceCallSite singletonCallSite, object argument) => VisitCallSiteMain(singletonCallSite, argument);
 
         protected override ILEmitCallSiteAnalysisResult VisitScopeCache(ServiceCallSite scopedCallSite, object argument)
         {
-            return new ILEmitCallSiteAnalysisResult(ScopedILSize, hasScope: true).Add(base.VisitScopeCache(scopedCallSite, argument));
+            return new ILEmitCallSiteAnalysisResult(ScopedILSize, hasScope: true).Add(VisitCallSiteMain(scopedCallSite, argument));
         }
 
         protected override ILEmitCallSiteAnalysisResult VisitConstant(ConstantCallSite constantCallSite, object argument) => new ILEmitCallSiteAnalysisResult(ConstantILSize);

--- a/src/DI/ServiceLookup/ILEmit/ILEmitCallSiteAnalyzer.cs
+++ b/src/DI/ServiceLookup/ILEmit/ILEmitCallSiteAnalyzer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         internal static ILEmitCallSiteAnalyzer Instance { get; } = new ILEmitCallSiteAnalyzer();
 
-        protected override ILEmitCallSiteAnalysisResult VisitTransient(IServiceCallSite transientCallSite, object argument) => base.VisitTransient(transientCallSite, argument);
+        protected override ILEmitCallSiteAnalysisResult VisitDisposeCache(ServiceCallSite transientCallSite, object argument) => base.VisitDisposeCache(transientCallSite, argument);
 
         protected override ILEmitCallSiteAnalysisResult VisitConstructor(ConstructorCallSite constructorCallSite, object argument)
         {
@@ -32,11 +32,11 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             return result;
         }
 
-        protected override ILEmitCallSiteAnalysisResult VisitSingleton(IServiceCallSite singletonCallSite, object argument) => base.VisitSingleton(singletonCallSite, argument);
+        protected override ILEmitCallSiteAnalysisResult VisitRootCache(ServiceCallSite singletonCallSite, object argument) => base.VisitRootCache(singletonCallSite, argument);
 
-        protected override ILEmitCallSiteAnalysisResult VisitScoped(IServiceCallSite scopedCallSite, object argument)
+        protected override ILEmitCallSiteAnalysisResult VisitScopeCache(ServiceCallSite scopedCallSite, object argument)
         {
-            return new ILEmitCallSiteAnalysisResult(ScopedILSize, hasScope: true).Add(base.VisitScoped(scopedCallSite, argument));
+            return new ILEmitCallSiteAnalysisResult(ScopedILSize, hasScope: true).Add(base.VisitScopeCache(scopedCallSite, argument));
         }
 
         protected override ILEmitCallSiteAnalysisResult VisitConstant(ConstantCallSite constantCallSite, object argument) => new ILEmitCallSiteAnalysisResult(ConstantILSize);
@@ -57,6 +57,6 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         protected override ILEmitCallSiteAnalysisResult VisitFactory(FactoryCallSite factoryCallSite, object argument) => new ILEmitCallSiteAnalysisResult(FactoryILSize);
 
-        public ILEmitCallSiteAnalysisResult CollectGenerationInfo(IServiceCallSite callSite) => VisitCallSite(callSite, null);
+        public ILEmitCallSiteAnalysisResult CollectGenerationInfo(ServiceCallSite callSite) => VisitCallSite(callSite, null);
     }
 }

--- a/src/DI/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
+++ b/src/DI/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         private readonly ServiceProviderEngineScope _rootScope;
 
         public ILEmitResolverBuilder(CallSiteRuntimeResolver runtimeResolver, IServiceScopeFactory serviceScopeFactory, ServiceProviderEngineScope rootScope) :
-            base(allowConcurrency: true)
+            base()
         {
             if (runtimeResolver == null)
             {

--- a/src/DI/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
+++ b/src/DI/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
@@ -269,7 +269,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         private void AddCacheKey(ILEmitResolverBuilderContext argument, ServiceCacheKey key)
         {
-            // new ServiceCacheKet(typeof(key.Type), key.Slot)
+            // new ServiceCacheKey(typeof(key.Type), key.Slot)
             argument.Generator.Emit(OpCodes.Ldtoken, key.Type);
             argument.Generator.Emit(OpCodes.Call, GetTypeFromHandleMethod);
             argument.Generator.Emit(OpCodes.Ldc_I4, key.Slot);
@@ -291,7 +291,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var info = ILEmitCallSiteAnalyzer.Instance.CollectGenerationInfo(callSite);
             var runtimeContext = GenerateMethodBody(callSite, dynamicMethod.GetILGenerator(info.Size), info);
 
-#if NET461
+#if SAVE_ASSEMBLY
             var assemblyName = "Test" + DateTime.Now.Ticks;
 
             var fileName = "Test" + DateTime.Now.Ticks;

--- a/src/DI/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
+++ b/src/DI/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             // }
 
             var resultLocal = argument.Generator.DeclareLocal(scopedCallSite.ServiceType);
-            var cacheKeyLocal = argument.Generator.DeclareLocal(typeof(object));
+            var cacheKeyLocal = argument.Generator.DeclareLocal(typeof(ServiceCacheKey));
             var endLabel = argument.Generator.DefineLabel();
 
             // Resolved services would be 0 local
@@ -290,7 +290,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var info = ILEmitCallSiteAnalyzer.Instance.CollectGenerationInfo(callSite);
             var runtimeContext = GenerateMethodBody(callSite, dynamicMethod.GetILGenerator(info.Size), info);
 
-#if SAVE_ASSEMBLY
+#if NET461
             var assemblyName = "Test" + DateTime.Now.Ticks;
 
             var fileName = "Test" + DateTime.Now.Ticks;
@@ -304,7 +304,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
             GenerateMethodBody(callSite, method.GetILGenerator(), info);
             type.CreateTypeInfo();
-            assembly.Save(assemblyName+".dll");
+            assembly.Save(assemblyName + ".dll");
 #endif
 
             return (Func<ServiceProviderEngineScope, object>)dynamicMethod.CreateDelegate(typeof(Func<ServiceProviderEngineScope, object>), runtimeContext);

--- a/src/DI/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
+++ b/src/DI/ServiceLookup/ILEmit/ILEmitResolverBuilder.cs
@@ -39,7 +39,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         private readonly ServiceProviderEngineScope _rootScope;
 
-        public ILEmitResolverBuilder(CallSiteRuntimeResolver runtimeResolver, IServiceScopeFactory serviceScopeFactory, ServiceProviderEngineScope rootScope)
+        public ILEmitResolverBuilder(CallSiteRuntimeResolver runtimeResolver, IServiceScopeFactory serviceScopeFactory, ServiceProviderEngineScope rootScope) :
+            base(allowConcurrency: true)
         {
             if (runtimeResolver == null)
             {

--- a/src/DI/ServiceLookup/ILEmit/ILEmitServiceProviderEngine.cs
+++ b/src/DI/ServiceLookup/ILEmit/ILEmitServiceProviderEngine.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             _expressionResolverBuilder = new ILEmitResolverBuilder(RuntimeResolver, this, Root);
         }
 
-        protected override Func<ServiceProviderEngineScope, object> RealizeService(IServiceCallSite callSite)
+        protected override Func<ServiceProviderEngineScope, object> RealizeService(ServiceCallSite callSite)
         {
             var realizedService = _expressionResolverBuilder.Build(callSite);
             RealizedServices[callSite.ServiceType] = realizedService;

--- a/src/DI/ServiceLookup/IServiceCallSite.cs
+++ b/src/DI/ServiceLookup/IServiceCallSite.cs
@@ -8,10 +8,53 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     /// <summary>
     /// Summary description for IServiceCallSite
     /// </summary>
-    internal interface IServiceCallSite
+    internal abstract class IServiceCallSite
     {
-        Type ServiceType { get; }
-        Type ImplementationType { get; }
-        CallSiteKind Kind { get; }
+        public IServiceCallSite(ResultCache cache)
+        {
+            Cache = cache;
+        }
+
+        public abstract Type ServiceType { get; }
+        public abstract Type ImplementationType { get; }
+        public abstract CallSiteKind Kind { get; }
+        public ResultCache Cache { get; }
+    }
+
+    internal enum CallSiteResultCacheLocation
+    {
+        Root,
+        Scope,
+        None
+    }
+
+    internal struct ResultCache
+    {
+        public ResultCache(CallSiteResultCacheLocation lifetime, object cacheKey)
+        {
+            Location = lifetime;
+            Key = cacheKey;
+        }
+
+
+        public ResultCache(ServiceLifetime lifetime, object cacheKey)
+        {
+            switch (lifetime)
+            {
+                case ServiceLifetime.Singleton:
+                    Location = CallSiteResultCacheLocation.Root;
+                    break;
+                case ServiceLifetime.Scoped:
+                    Location = CallSiteResultCacheLocation.Root;
+                    break;
+                default:
+                    Location = CallSiteResultCacheLocation.None;
+                    break;
+            }
+            Key = cacheKey;
+        }
+
+        public CallSiteResultCacheLocation Location { get; set; }
+        public object Key { get; set; }
     }
 }

--- a/src/DI/ServiceLookup/IServiceProviderEngineCallback.cs
+++ b/src/DI/ServiceLookup/IServiceProviderEngineCallback.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal interface IServiceProviderEngineCallback
     {
-        void OnCreate(IServiceCallSite callSite);
+        void OnCreate(ServiceCallSite callSite);
         void OnResolve(Type serviceType, IServiceScope scope);
     }
 }

--- a/src/DI/ServiceLookup/ResultCache.cs
+++ b/src/DI/ServiceLookup/ResultCache.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
+{
+    internal struct ResultCache
+    {
+        public static ResultCache None { get; } = new ResultCache(CallSiteResultCacheLocation.None, ServiceCacheKey.Empty);
+
+        internal ResultCache(CallSiteResultCacheLocation lifetime, ServiceCacheKey cacheKey)
+        {
+            Location = lifetime;
+            Key = cacheKey;
+        }
+
+        public ResultCache(ServiceLifetime lifetime, Type type, int slot)
+        {
+            Debug.Assert(lifetime == ServiceLifetime.Transient || type != null);
+
+            switch (lifetime)
+            {
+                case ServiceLifetime.Singleton:
+                    Location = CallSiteResultCacheLocation.Root;
+                    break;
+                case ServiceLifetime.Scoped:
+                    Location = CallSiteResultCacheLocation.Scope;
+                    break;
+                case ServiceLifetime.Transient:
+                    Location = CallSiteResultCacheLocation.Dispose;
+                    break;
+                default:
+                    Location = CallSiteResultCacheLocation.None;
+                    break;
+            }
+            Key = new ServiceCacheKey(type, slot);
+        }
+
+        public CallSiteResultCacheLocation Location { get; set; }
+
+        public ServiceCacheKey Key { get; set; }
+    }
+}

--- a/src/DI/ServiceLookup/RuntimeServiceProviderEngine.cs
+++ b/src/DI/ServiceLookup/RuntimeServiceProviderEngine.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
         }
 
-        protected override Func<ServiceProviderEngineScope, object> RealizeService(IServiceCallSite callSite)
+        protected override Func<ServiceProviderEngineScope, object> RealizeService(ServiceCallSite callSite)
         {
             return scope =>
             {

--- a/src/DI/ServiceLookup/ScopedCallSite.cs
+++ b/src/DI/ServiceLookup/ScopedCallSite.cs
@@ -5,19 +5,5 @@ using System;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
-    internal class ScopedCallSite : IServiceCallSite
-    {
-        internal IServiceCallSite ServiceCallSite { get; }
-        public object CacheKey { get; }
 
-        public ScopedCallSite(IServiceCallSite serviceCallSite, object cacheKey)
-        {
-            ServiceCallSite = serviceCallSite;
-            CacheKey = cacheKey;
-        }
-
-        public Type ServiceType => ServiceCallSite.ServiceType;
-        public Type ImplementationType => ServiceCallSite.ImplementationType;
-        public virtual CallSiteKind Kind { get; } = CallSiteKind.Scope;
-    }
 }

--- a/src/DI/ServiceLookup/ServiceCacheKey.cs
+++ b/src/DI/ServiceLookup/ServiceCacheKey.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
+{
+    internal struct ServiceCacheKey: IEquatable<ServiceCacheKey>
+    {
+        public static ServiceCacheKey Empty { get; } = new ServiceCacheKey(null, 0);
+
+        /// <summary>
+        /// Type of service being cached
+        /// </summary>
+        public Type Type { get; }
+
+        /// <summary>
+        /// Reverse index of the service when resolved in <code>IEnumerable&lt;Type&gt;</code> where default instance gets slot 0.
+        /// For example for service collection
+        ///  IService Impl1
+        ///  IService Impl2
+        ///  IService Impl3
+        /// We would get the following cache keys:
+        ///  Impl1 2
+        ///  Impl2 1
+        ///  Impl3 0
+        /// </summary>
+        public int Slot { get; }
+
+        public ServiceCacheKey(Type type, int slot)
+        {
+            Type = type;
+            Slot = slot;
+        }
+
+        public bool Equals(ServiceCacheKey other)
+        {
+            return Type == other.Type && Slot == other.Slot;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Type.GetHashCode() * 397) ^ Slot;
+            }
+        }
+    }
+}

--- a/src/DI/ServiceLookup/ServiceCallSite.cs
+++ b/src/DI/ServiceLookup/ServiceCallSite.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
@@ -12,7 +10,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     /// </summary>
     internal abstract class ServiceCallSite
     {
-        public ServiceCallSite(ResultCache cache)
+        protected ServiceCallSite(ResultCache cache)
         {
             Cache = cache;
         }
@@ -21,75 +19,5 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         public abstract Type ImplementationType { get; }
         public abstract CallSiteKind Kind { get; }
         public ResultCache Cache { get; }
-    }
-
-    internal enum CallSiteResultCacheLocation
-    {
-        Root,
-        Scope,
-        Dispose,
-        None
-    }
-
-    internal struct ServiceCacheKey: IEquatable<ServiceCacheKey>
-    {
-        public Type Type { get; }
-        public int Slot { get; }
-        public static ServiceCacheKey Enpty { get; } = new ServiceCacheKey(null, 0);
-
-        public ServiceCacheKey(Type type, int slot)
-        {
-            Type = type;
-            Slot = slot;
-        }
-
-        public bool Equals(ServiceCacheKey other)
-        {
-            return Type == other.Type && Slot == other.Slot;
-        }
-
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return (Type.GetHashCode() * 397) ^ Slot;
-            }
-        }
-    }
-
-    internal struct ResultCache
-    {
-        public static ResultCache None { get; } = new ResultCache(CallSiteResultCacheLocation.None, ServiceCacheKey.Enpty);
-
-        public ResultCache(CallSiteResultCacheLocation lifetime, ServiceCacheKey cacheKey)
-        {
-            Location = lifetime;
-            Key = cacheKey;
-        }
-
-        public ResultCache(ServiceLifetime lifetime, Type type, int slot)
-        {
-            Debug.Assert(lifetime == ServiceLifetime.Transient || type != null);
-
-            switch (lifetime)
-            {
-                case ServiceLifetime.Singleton:
-                    Location = CallSiteResultCacheLocation.Root;
-                    break;
-                case ServiceLifetime.Scoped:
-                    Location = CallSiteResultCacheLocation.Scope;
-                    break;
-                case ServiceLifetime.Transient:
-                    Location = CallSiteResultCacheLocation.Dispose;
-                    break;
-                default:
-                    Location = CallSiteResultCacheLocation.None;
-                    break;
-            }
-            Key = new ServiceCacheKey(type, slot);
-        }
-
-        public CallSiteResultCacheLocation Location { get; set; }
-        public ServiceCacheKey Key { get; set; }
     }
 }

--- a/src/DI/ServiceLookup/ServiceCallSite.cs
+++ b/src/DI/ServiceLookup/ServiceCallSite.cs
@@ -8,9 +8,9 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     /// <summary>
     /// Summary description for IServiceCallSite
     /// </summary>
-    internal abstract class IServiceCallSite
+    internal abstract class ServiceCallSite
     {
-        public IServiceCallSite(ResultCache cache)
+        public ServiceCallSite(ResultCache cache)
         {
             Cache = cache;
         }
@@ -25,27 +25,37 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     {
         Root,
         Scope,
+        Dispose,
         None
     }
 
     internal struct ResultCache
     {
+        public static ResultCache None { get; } = new ResultCache(CallSiteResultCacheLocation.None, null);
+
         public ResultCache(CallSiteResultCacheLocation lifetime, object cacheKey)
         {
             Location = lifetime;
             Key = cacheKey;
         }
 
-
         public ResultCache(ServiceLifetime lifetime, object cacheKey)
         {
+            if (lifetime != ServiceLifetime.Transient && cacheKey == null)
+            {
+                throw new ArgumentNullException(nameof(cacheKey));
+            }
+
             switch (lifetime)
             {
                 case ServiceLifetime.Singleton:
                     Location = CallSiteResultCacheLocation.Root;
                     break;
                 case ServiceLifetime.Scoped:
-                    Location = CallSiteResultCacheLocation.Root;
+                    Location = CallSiteResultCacheLocation.Scope;
+                    break;
+                case ServiceLifetime.Transient:
+                    Location = CallSiteResultCacheLocation.Dispose;
                     break;
                 default:
                     Location = CallSiteResultCacheLocation.None;

--- a/src/DI/ServiceLookup/ServiceProviderCallSite.cs
+++ b/src/DI/ServiceLookup/ServiceProviderCallSite.cs
@@ -5,9 +5,9 @@ using System;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
-    internal class ServiceProviderCallSite : IServiceCallSite
+    internal class ServiceProviderCallSite : ServiceCallSite
     {
-        public ServiceProviderCallSite() : base(new ResultCache(ServiceLifetime.Singleton, null))
+        public ServiceProviderCallSite() : base(ResultCache.None)
         {
         }
 

--- a/src/DI/ServiceLookup/ServiceProviderCallSite.cs
+++ b/src/DI/ServiceLookup/ServiceProviderCallSite.cs
@@ -7,8 +7,12 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal class ServiceProviderCallSite : IServiceCallSite
     {
-        public Type ServiceType { get; } = typeof(IServiceProvider);
-        public Type ImplementationType { get; } = typeof(ServiceProvider);
-        public CallSiteKind Kind { get; } = CallSiteKind.ServiceProvider;
+        public ServiceProviderCallSite() : base(new ResultCache(ServiceLifetime.Singleton, null))
+        {
+        }
+
+        public override Type ServiceType { get; } = typeof(IServiceProvider);
+        public override Type ImplementationType { get; } = typeof(ServiceProvider);
+        public override CallSiteKind Kind { get; } = CallSiteKind.ServiceProvider;
     }
 }

--- a/src/DI/ServiceLookup/ServiceProviderEngine.cs
+++ b/src/DI/ServiceLookup/ServiceProviderEngine.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         private Func<ServiceProviderEngineScope, object> CreateServiceAccessor(Type serviceType)
         {
-            var callSite = CallSiteFactory.CreateCallSite(serviceType, new CallSiteChain());
+            var callSite = CallSiteFactory.GetCallSite(serviceType, new CallSiteChain());
             if (callSite != null)
             {
                 _callback?.OnCreate(callSite);

--- a/src/DI/ServiceLookup/ServiceProviderEngine.cs
+++ b/src/DI/ServiceLookup/ServiceProviderEngine.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         public object GetService(Type serviceType) => GetService(serviceType, Root);
 
-        protected abstract Func<ServiceProviderEngineScope, object> RealizeService(IServiceCallSite callSite);
+        protected abstract Func<ServiceProviderEngineScope, object> RealizeService(ServiceCallSite callSite);
 
         public void Dispose()
         {

--- a/src/DI/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/DI/ServiceLookup/ServiceProviderEngineScope.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             Engine = engine;
         }
 
-        internal Dictionary<object, object> ResolvedServices { get; } = new Dictionary<object, object>();
+        internal Dictionary<ServiceCacheKey, object> ResolvedServices { get; } = new Dictionary<ServiceCacheKey, object>();
 
         public ServiceProviderEngine Engine { get; }
 

--- a/src/DI/ServiceLookup/ServiceScopeFactoryCallSite.cs
+++ b/src/DI/ServiceLookup/ServiceScopeFactoryCallSite.cs
@@ -7,8 +7,12 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal class ServiceScopeFactoryCallSite : IServiceCallSite
     {
-        public Type ServiceType { get; } = typeof(IServiceScopeFactory);
-        public Type ImplementationType { get; } = typeof(ServiceProviderEngine);
-        public CallSiteKind Kind { get; } = CallSiteKind.ServiceScopeFactory;
+        public ServiceScopeFactoryCallSite() : base(new ResultCache(ServiceLifetime.Singleton, null))
+        {
+        }
+
+        public override Type ServiceType { get; } = typeof(IServiceScopeFactory);
+        public override Type ImplementationType { get; } = typeof(ServiceProviderEngine);
+        public override CallSiteKind Kind { get; } = CallSiteKind.ServiceScopeFactory;
     }
 }

--- a/src/DI/ServiceLookup/ServiceScopeFactoryCallSite.cs
+++ b/src/DI/ServiceLookup/ServiceScopeFactoryCallSite.cs
@@ -5,9 +5,9 @@ using System;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
-    internal class ServiceScopeFactoryCallSite : IServiceCallSite
+    internal class ServiceScopeFactoryCallSite : ServiceCallSite
     {
-        public ServiceScopeFactoryCallSite() : base(new ResultCache(ServiceLifetime.Singleton, null))
+        public ServiceScopeFactoryCallSite() : base(ResultCache.None)
         {
         }
 

--- a/src/DI/ServiceLookup/SingletonCallSite.cs
+++ b/src/DI/ServiceLookup/SingletonCallSite.cs
@@ -3,12 +3,4 @@
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
-    internal class SingletonCallSite : ScopedCallSite
-    {
-        public SingletonCallSite(IServiceCallSite serviceCallSite, object cacheKey) : base(serviceCallSite, cacheKey)
-        {
-        }
-
-        public override CallSiteKind Kind { get; } = CallSiteKind.Singleton;
-    }
 }

--- a/src/DI/ServiceLookup/StackGuard.cs
+++ b/src/DI/ServiceLookup/StackGuard.cs
@@ -11,16 +11,10 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal sealed class StackGuard
     {
-        private readonly bool _allowConcurrency;
-
         private const int MaxExecutionStackCount = 1024;
 
         private int _executionStackCount;
 
-        public StackGuard(bool allowConcurrency)
-        {
-            _allowConcurrency = allowConcurrency;
-        }
 
         public bool TryEnterOnCurrentStack()
         {
@@ -40,7 +34,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             }
 #endif
 
-            if (_allowConcurrency && _executionStackCount < MaxExecutionStackCount)
+            if (_executionStackCount < MaxExecutionStackCount)
             {
                 return false;
             }

--- a/src/DI/ServiceLookup/StackGuard.cs
+++ b/src/DI/ServiceLookup/StackGuard.cs
@@ -1,0 +1,87 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
+{
+    internal sealed class StackGuard
+    {
+        private readonly bool _allowConcurrency;
+
+        private const int MaxExecutionStackCount = 1024;
+
+        private int _executionStackCount;
+
+        public StackGuard(bool allowConcurrency)
+        {
+            _allowConcurrency = allowConcurrency;
+        }
+
+        public bool TryEnterOnCurrentStack()
+        {
+#if NETCOREAPP2_0
+            if (RuntimeHelpers.TryEnsureSufficientExecutionStack())
+            {
+                return true;
+            }
+#else
+            try
+            {
+                RuntimeHelpers.EnsureSufficientExecutionStack();
+                return true;
+            }
+            catch (InsufficientExecutionStackException)
+            {
+            }
+#endif
+
+            if (_allowConcurrency && _executionStackCount < MaxExecutionStackCount)
+            {
+                return false;
+            }
+
+            throw new InsufficientExecutionStackException();
+        }
+
+        public TR RunOnEmptyStack<T1, T2, TR>(Func<T1, T2, TR> action, T1 arg1, T2 arg2)
+        {
+            return RunOnEmptyStackCore(s =>
+            {
+                var t = (Tuple<Func<T1, T2, TR>, T1, T2>)s;
+                return t.Item1(t.Item2, t.Item3);
+            }, Tuple.Create(action, arg1, arg2));
+        }
+
+        private R RunOnEmptyStackCore<R>(Func<object, R> action, object state)
+        {
+            _executionStackCount++;
+
+            try
+            {
+                // Using default scheduler rather than picking up the current scheduler.
+                Task<R> task = Task.Factory.StartNew(action, state, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+
+                TaskAwaiter<R> awaiter = task.GetAwaiter();
+
+                // Avoid AsyncWaitHandle lazy allocation of ManualResetEvent in the rare case we finish quickly.
+                if (!awaiter.IsCompleted)
+                {
+                    // Task.Wait has the potential of inlining the task's execution on the current thread; avoid this.
+                    ((IAsyncResult)task).AsyncWaitHandle.WaitOne();
+                }
+
+                // Using awaiter here to unwrap AggregateException.
+                return awaiter.GetResult();
+            }
+            finally
+            {
+                _executionStackCount--;
+            }
+        }
+    }
+}

--- a/src/DI/ServiceLookup/TransientCallSite.cs
+++ b/src/DI/ServiceLookup/TransientCallSite.cs
@@ -5,17 +5,5 @@ using System;
 
 namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
-    internal class TransientCallSite : IServiceCallSite
-    {
-        internal IServiceCallSite ServiceCallSite { get; }
 
-        public TransientCallSite(IServiceCallSite serviceCallSite)
-        {
-            ServiceCallSite = serviceCallSite;
-        }
-
-        public Type ServiceType => ServiceCallSite.ServiceType;
-        public Type ImplementationType => ServiceCallSite.ImplementationType;
-        public CallSiteKind Kind { get; } = CallSiteKind.Transient;
-    }
 }

--- a/src/DI/ServiceLookup/TransientCallSite.cs
+++ b/src/DI/ServiceLookup/TransientCallSite.cs
@@ -1,9 +1,0 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-using System;
-
-namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
-{
-
-}

--- a/src/DI/ServiceProvider.cs
+++ b/src/DI/ServiceProvider.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <inheritdoc />
         public void Dispose() => _engine.Dispose();
 
-        void IServiceProviderEngineCallback.OnCreate(IServiceCallSite callSite)
+        void IServiceProviderEngineCallback.OnCreate(ServiceCallSite callSite)
         {
             _callSiteValidator.ValidateCallSite(callSite);
         }

--- a/test/DI.Tests/CallSiteTests.cs
+++ b/test/DI.Tests/CallSiteTests.cs
@@ -311,12 +311,12 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             }
         }
 
-        private static object Invoke(IServiceCallSite callSite, ServiceProviderEngine provider)
+        private static object Invoke(ServiceCallSite callSite, ServiceProviderEngine provider)
         {
             return CallSiteRuntimeResolver.Resolve(callSite, provider.Root);
         }
 
-        private static Func<ServiceProviderEngineScope, object> CompileCallSite(IServiceCallSite callSite, ServiceProviderEngine engine)
+        private static Func<ServiceProviderEngineScope, object> CompileCallSite(ServiceCallSite callSite, ServiceProviderEngine engine)
         {
             return new ExpressionResolverBuilder(CallSiteRuntimeResolver, engine, engine.Root).Build(callSite);
         }

--- a/test/DI.Tests/CallSiteTests.cs
+++ b/test/DI.Tests/CallSiteTests.cs
@@ -29,6 +29,20 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                 compare = (service1, service2) => service1 == service2;
             }
 
+            // Implementation Type Descriptor
+            yield return new object[]
+            {
+                new[] { new ServiceDescriptor(typeof(IFakeService), typeof(FakeService), lifetime) },
+                typeof(IFakeService),
+                compare,
+            };
+            // Closed Generic Descriptor
+            yield return new object[]
+            {
+                new[] { new ServiceDescriptor(typeof(IFakeOpenGenericService<PocoClass>), typeof(FakeService), lifetime) },
+                typeof(IFakeOpenGenericService<PocoClass>),
+                compare,
+            };
             // Open Generic Descriptor
             yield return new object[]
             {
@@ -40,45 +54,30 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                 typeof(IFakeOpenGenericService<IFakeService>),
                 compare,
             };
+            // Factory Descriptor
+            yield return new object[]
+            {
+                new[] { new ServiceDescriptor(typeof(IFakeService), _ => new FakeService(), lifetime) },
+                typeof(IFakeService),
+                compare,
+            };
 
-            //// Implementation Type Descriptor
-            //yield return new object[]
-            //{
-            //    new[] { new ServiceDescriptor(typeof(IFakeService), typeof(FakeService), lifetime) },
-            //    typeof(IFakeService),
-            //    compare,
-            //};
-            //// Closed Generic Descriptor
-            //yield return new object[]
-            //{
-            //    new[] { new ServiceDescriptor(typeof(IFakeOpenGenericService<PocoClass>), typeof(FakeService), lifetime) },
-            //    typeof(IFakeOpenGenericService<PocoClass>),
-            //    compare,
-            //};
-            //// Factory Descriptor
-            //yield return new object[]
-            //{
-            //    new[] { new ServiceDescriptor(typeof(IFakeService), _ => new FakeService(), lifetime) },
-            //    typeof(IFakeService),
-            //    compare,
-            //};
-
-            //if (lifetime == ServiceLifetime.Singleton)
-            //{
-            //    // Instance Descriptor
-            //    yield return new object[]
-            //    {
-            //       new[] { new ServiceDescriptor(typeof(IFakeService), new FakeService()) },
-            //       typeof(IFakeService),
-            //       compare,
-            //    };
-            //}
+            if (lifetime == ServiceLifetime.Singleton)
+            {
+                // Instance Descriptor
+                yield return new object[]
+                {
+                   new[] { new ServiceDescriptor(typeof(IFakeService), new FakeService()) },
+                   typeof(IFakeService),
+                   compare,
+                };
+            }
         }
 
         [Theory]
         [MemberData(nameof(TestServiceDescriptors), ServiceLifetime.Singleton)]
-        //[MemberData(nameof(TestServiceDescriptors), ServiceLifetime.Scoped)]
-        //[MemberData(nameof(TestServiceDescriptors), ServiceLifetime.Transient)]
+        [MemberData(nameof(TestServiceDescriptors), ServiceLifetime.Scoped)]
+        [MemberData(nameof(TestServiceDescriptors), ServiceLifetime.Transient)]
         public void BuiltExpressionWillReturnResolvedServiceWhenAppropriate(
             ServiceDescriptor[] descriptors, Type serviceType, Func<object, object, bool> compare)
         {

--- a/test/DI.Tests/CallSiteTests.cs
+++ b/test/DI.Tests/CallSiteTests.cs
@@ -29,20 +29,6 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                 compare = (service1, service2) => service1 == service2;
             }
 
-            // Implementation Type Descriptor
-            yield return new object[]
-            {
-                new[] { new ServiceDescriptor(typeof(IFakeService), typeof(FakeService), lifetime) },
-                typeof(IFakeService),
-                compare,
-            };
-            // Closed Generic Descriptor
-            yield return new object[]
-            {
-                new[] { new ServiceDescriptor(typeof(IFakeOpenGenericService<PocoClass>), typeof(FakeService), lifetime) },
-                typeof(IFakeOpenGenericService<PocoClass>),
-                compare,
-            };
             // Open Generic Descriptor
             yield return new object[]
             {
@@ -54,37 +40,52 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                 typeof(IFakeOpenGenericService<IFakeService>),
                 compare,
             };
-            // Factory Descriptor
-            yield return new object[]
-            {
-                new[] { new ServiceDescriptor(typeof(IFakeService), _ => new FakeService(), lifetime) },
-                typeof(IFakeService),
-                compare,
-            };
 
-            if (lifetime == ServiceLifetime.Singleton)
-            {
-                // Instance Descriptor
-                yield return new object[]
-                {
-                   new[] { new ServiceDescriptor(typeof(IFakeService), new FakeService()) },
-                   typeof(IFakeService),
-                   compare,
-                };
-            }
+            //// Implementation Type Descriptor
+            //yield return new object[]
+            //{
+            //    new[] { new ServiceDescriptor(typeof(IFakeService), typeof(FakeService), lifetime) },
+            //    typeof(IFakeService),
+            //    compare,
+            //};
+            //// Closed Generic Descriptor
+            //yield return new object[]
+            //{
+            //    new[] { new ServiceDescriptor(typeof(IFakeOpenGenericService<PocoClass>), typeof(FakeService), lifetime) },
+            //    typeof(IFakeOpenGenericService<PocoClass>),
+            //    compare,
+            //};
+            //// Factory Descriptor
+            //yield return new object[]
+            //{
+            //    new[] { new ServiceDescriptor(typeof(IFakeService), _ => new FakeService(), lifetime) },
+            //    typeof(IFakeService),
+            //    compare,
+            //};
+
+            //if (lifetime == ServiceLifetime.Singleton)
+            //{
+            //    // Instance Descriptor
+            //    yield return new object[]
+            //    {
+            //       new[] { new ServiceDescriptor(typeof(IFakeService), new FakeService()) },
+            //       typeof(IFakeService),
+            //       compare,
+            //    };
+            //}
         }
 
         [Theory]
         [MemberData(nameof(TestServiceDescriptors), ServiceLifetime.Singleton)]
-        [MemberData(nameof(TestServiceDescriptors), ServiceLifetime.Scoped)]
-        [MemberData(nameof(TestServiceDescriptors), ServiceLifetime.Transient)]
+        //[MemberData(nameof(TestServiceDescriptors), ServiceLifetime.Scoped)]
+        //[MemberData(nameof(TestServiceDescriptors), ServiceLifetime.Transient)]
         public void BuiltExpressionWillReturnResolvedServiceWhenAppropriate(
             ServiceDescriptor[] descriptors, Type serviceType, Func<object, object, bool> compare)
         {
             var provider = new DynamicServiceProviderEngine(descriptors, null);
 
-            var callSite = provider.CallSiteFactory.CreateCallSite(serviceType, new CallSiteChain());
-            var collectionCallSite = provider.CallSiteFactory.CreateCallSite(typeof(IEnumerable<>).MakeGenericType(serviceType), new CallSiteChain());
+            var callSite = provider.CallSiteFactory.GetCallSite(serviceType, new CallSiteChain());
+            var collectionCallSite = provider.CallSiteFactory.GetCallSite(typeof(IEnumerable<>).MakeGenericType(serviceType), new CallSiteChain());
 
             var compiledCallSite = CompileCallSite(callSite, provider);
             var compiledCollectionCallSite = CompileCallSite(collectionCallSite, provider);
@@ -111,7 +112,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             descriptors.AddScoped<ServiceC>();
 
             var provider = new DynamicServiceProviderEngine(descriptors, null);
-            var callSite = provider.CallSiteFactory.CreateCallSite(typeof(ServiceC), new CallSiteChain());
+            var callSite = provider.CallSiteFactory.GetCallSite(typeof(ServiceC), new CallSiteChain());
             var compiledCallSite = CompileCallSite(callSite, provider);
 
             var serviceC = (ServiceC)compiledCallSite(provider.Root);
@@ -137,7 +138,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             {
                 disposables.Add(obj);
             };
-            var callSite = provider.CallSiteFactory.CreateCallSite(typeof(ServiceC), new CallSiteChain());
+            var callSite = provider.CallSiteFactory.GetCallSite(typeof(ServiceC), new CallSiteChain());
             var compiledCallSite = CompileCallSite(callSite, provider);
 
             var serviceC = (DisposableServiceC)compiledCallSite(provider.Root);
@@ -163,7 +164,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             {
                 disposables.Add(obj);
             };
-            var callSite = provider.CallSiteFactory.CreateCallSite(typeof(ServiceC), new CallSiteChain());
+            var callSite = provider.CallSiteFactory.GetCallSite(typeof(ServiceC), new CallSiteChain());
             var compiledCallSite = CompileCallSite(callSite, provider);
 
             var serviceC = (DisposableServiceC)compiledCallSite(provider.Root);
@@ -192,7 +193,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             {
                 disposables.Add(obj);
             };
-            var callSite = provider.CallSiteFactory.CreateCallSite(typeof(ServiceC), new CallSiteChain());
+            var callSite = provider.CallSiteFactory.GetCallSite(typeof(ServiceC), new CallSiteChain());
             var compiledCallSite = CompileCallSite(callSite, provider);
 
             var serviceC = (ServiceC)compiledCallSite(provider.Root);
@@ -217,7 +218,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             {
                 disposables.Add(obj);
             };
-            var callSite = provider.CallSiteFactory.CreateCallSite(typeof(ServiceD), new CallSiteChain());
+            var callSite = provider.CallSiteFactory.GetCallSite(typeof(ServiceD), new CallSiteChain());
             var compiledCallSite = CompileCallSite(callSite, provider);
 
             var serviceD = (ServiceD)compiledCallSite(provider.Root);
@@ -235,10 +236,10 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
 
             var provider = new DynamicServiceProviderEngine(descriptors, null);
 
-            var callSite1 = provider.CallSiteFactory.CreateCallSite(typeof(ClassWithThrowingEmptyCtor), new CallSiteChain());
+            var callSite1 = provider.CallSiteFactory.GetCallSite(typeof(ClassWithThrowingEmptyCtor), new CallSiteChain());
             var compiledCallSite1 = CompileCallSite(callSite1, provider);
 
-            var callSite2 = provider.CallSiteFactory.CreateCallSite(typeof(ClassWithThrowingCtor), new CallSiteChain());
+            var callSite2 = provider.CallSiteFactory.GetCallSite(typeof(ClassWithThrowingCtor), new CallSiteChain());
             var compiledCallSite2 = CompileCallSite(callSite2, provider);
 
             var ex1 = Assert.Throws<Exception>(() => compiledCallSite1(provider.Root));

--- a/test/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
+++ b/test/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
@@ -42,8 +42,9 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var callSite = callSiteFactory(type);
 
             // Assert
-            var transientCall = Assert.IsType<TransientCallSite>(callSite);
-            Assert.IsType<CreateInstanceCallSite>(transientCall.ServiceCallSite);
+            Assert.Equal(CallSiteResultCacheLocation.None, callSite.Cache.Location);
+            var ctroCallSite = Assert.IsType<ConstructorCallSite>(callSite);
+            Assert.Empty(ctroCallSite.ParameterCallSites);
         }
 
         [Theory]
@@ -65,8 +66,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var callSite = callSiteFactory(type);
 
             // Assert
-            var transientCall = Assert.IsType<TransientCallSite>(callSite);
-            var constructorCallSite = Assert.IsType<ConstructorCallSite>(transientCall.ServiceCallSite);
+            Assert.Equal(CallSiteResultCacheLocation.None, callSite.Cache.Location);
+            var constructorCallSite = Assert.IsType<ConstructorCallSite>(callSite);
             Assert.Equal(new[] { typeof(IFakeService) }, GetParameters(constructorCallSite));
         }
 
@@ -86,8 +87,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var callSite = callSiteFactory(type);
 
             // Assert
-            var transientCall = Assert.IsType<TransientCallSite>(callSite);
-            var constructorCallSite = Assert.IsType<ConstructorCallSite>(transientCall.ServiceCallSite);
+            Assert.Equal(CallSiteResultCacheLocation.None, callSite.Cache.Location);
+            var constructorCallSite = Assert.IsType<ConstructorCallSite>(callSite);
             Assert.Equal(
                 new[] { typeof(IEnumerable<IFakeService>), typeof(IEnumerable<IFactoryService>) },
                 GetParameters(constructorCallSite));
@@ -105,12 +106,13 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var callSite = callSiteFactory(type);
 
             // Assert
-            var transientCall = Assert.IsType<TransientCallSite>(callSite);
-            Assert.IsType<CreateInstanceCallSite>(transientCall.ServiceCallSite);
+            Assert.Equal(CallSiteResultCacheLocation.None, callSite.Cache.Location);
+            var ctorCallSite = Assert.IsType<ConstructorCallSite>(callSite);
+            Assert.Empty(ctorCallSite.ParameterCallSites);
         }
 
         public static TheoryData CreateCallSite_PicksConstructorWithTheMostNumberOfResolvedParametersData =>
-            new TheoryData<Type, Func<Type, object>, Type[]>
+            new TheoryData<Type, Func<Type, IServiceCallSite>, Type[]>
             {
                 {
                     typeof(TypeWithSupersetConstructors),
@@ -192,17 +194,17 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         [Theory]
         [MemberData(nameof(CreateCallSite_PicksConstructorWithTheMostNumberOfResolvedParametersData))]
-        public void CreateCallSite_PicksConstructorWithTheMostNumberOfResolvedParameters(
+        private void CreateCallSite_PicksConstructorWithTheMostNumberOfResolvedParameters(
             Type type,
-            Func<Type, object> callSiteFactory,
+            Func<Type, IServiceCallSite> callSiteFactory,
             Type[] expectedConstructorParameters)
         {
             // Act
             var callSite = callSiteFactory(type);
 
             // Assert
-            var transientCall = Assert.IsType<TransientCallSite>(callSite);
-            var constructorCallSite = Assert.IsType<ConstructorCallSite>(transientCall.ServiceCallSite);
+            Assert.Equal(CallSiteResultCacheLocation.None, callSite.Cache.Location);
+            var constructorCallSite = Assert.IsType<ConstructorCallSite>(callSite);
             Assert.Equal(expectedConstructorParameters, GetParameters(constructorCallSite));
         }
 
@@ -235,8 +237,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
         [Theory]
         [MemberData(nameof(CreateCallSite_ConsidersConstructorsWithDefaultValuesData))]
-        public void CreateCallSite_ConsidersConstructorsWithDefaultValues(
-            Func<Type, object> callSiteFactory,
+        private void CreateCallSite_ConsidersConstructorsWithDefaultValues(
+            Func<Type, IServiceCallSite> callSiteFactory,
             Type[] expectedConstructorParameters)
         {
             // Arrange
@@ -246,8 +248,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var callSite = callSiteFactory(type);
 
             // Assert
-            var transientCall = Assert.IsType<TransientCallSite>(callSite);
-            var constructorCallSite = Assert.IsType<ConstructorCallSite>(transientCall.ServiceCallSite);
+            Assert.Equal(CallSiteResultCacheLocation.None, callSite.Cache.Location);
+            var constructorCallSite = Assert.IsType<ConstructorCallSite>(callSite);
             Assert.Equal(expectedConstructorParameters, GetParameters(constructorCallSite));
         }
 
@@ -398,7 +400,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             Assert.StartsWith(expectedMessage, ex.Message);
         }
 
-        private static Func<Type, object> GetCallSiteFactory(params ServiceDescriptor[] descriptors)
+        private static Func<Type, IServiceCallSite> GetCallSiteFactory(params ServiceDescriptor[] descriptors)
         {
             var collection = new ServiceCollection();
             foreach (var descriptor in descriptors)

--- a/test/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
+++ b/test/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
@@ -410,7 +410,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 
             var callSiteFactory = new CallSiteFactory(collection.ToArray());
 
-            return type => callSiteFactory.CreateCallSite(type, new CallSiteChain());
+            return type => callSiteFactory.GetCallSite(type, new CallSiteChain());
         }
 
         private static IEnumerable<Type> GetParameters(ConstructorCallSite constructorCallSite) =>

--- a/test/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
+++ b/test/DI.Tests/ServiceLookup/CallSiteFactoryTest.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var callSite = callSiteFactory(type);
 
             // Assert
-            Assert.Equal(CallSiteResultCacheLocation.None, callSite.Cache.Location);
+            Assert.Equal(CallSiteResultCacheLocation.Dispose, callSite.Cache.Location);
             var ctroCallSite = Assert.IsType<ConstructorCallSite>(callSite);
             Assert.Empty(ctroCallSite.ParameterCallSites);
         }
@@ -66,7 +66,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var callSite = callSiteFactory(type);
 
             // Assert
-            Assert.Equal(CallSiteResultCacheLocation.None, callSite.Cache.Location);
+            Assert.Equal(CallSiteResultCacheLocation.Dispose, callSite.Cache.Location);
             var constructorCallSite = Assert.IsType<ConstructorCallSite>(callSite);
             Assert.Equal(new[] { typeof(IFakeService) }, GetParameters(constructorCallSite));
         }
@@ -87,7 +87,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var callSite = callSiteFactory(type);
 
             // Assert
-            Assert.Equal(CallSiteResultCacheLocation.None, callSite.Cache.Location);
+            Assert.Equal(CallSiteResultCacheLocation.Dispose, callSite.Cache.Location);
             var constructorCallSite = Assert.IsType<ConstructorCallSite>(callSite);
             Assert.Equal(
                 new[] { typeof(IEnumerable<IFakeService>), typeof(IEnumerable<IFactoryService>) },
@@ -106,13 +106,13 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var callSite = callSiteFactory(type);
 
             // Assert
-            Assert.Equal(CallSiteResultCacheLocation.None, callSite.Cache.Location);
+            Assert.Equal(CallSiteResultCacheLocation.Dispose, callSite.Cache.Location);
             var ctorCallSite = Assert.IsType<ConstructorCallSite>(callSite);
             Assert.Empty(ctorCallSite.ParameterCallSites);
         }
 
         public static TheoryData CreateCallSite_PicksConstructorWithTheMostNumberOfResolvedParametersData =>
-            new TheoryData<Type, Func<Type, IServiceCallSite>, Type[]>
+            new TheoryData<Type, Func<Type, ServiceCallSite>, Type[]>
             {
                 {
                     typeof(TypeWithSupersetConstructors),
@@ -196,14 +196,14 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         [MemberData(nameof(CreateCallSite_PicksConstructorWithTheMostNumberOfResolvedParametersData))]
         private void CreateCallSite_PicksConstructorWithTheMostNumberOfResolvedParameters(
             Type type,
-            Func<Type, IServiceCallSite> callSiteFactory,
+            Func<Type, ServiceCallSite> callSiteFactory,
             Type[] expectedConstructorParameters)
         {
             // Act
             var callSite = callSiteFactory(type);
 
             // Assert
-            Assert.Equal(CallSiteResultCacheLocation.None, callSite.Cache.Location);
+            Assert.Equal(CallSiteResultCacheLocation.Dispose, callSite.Cache.Location);
             var constructorCallSite = Assert.IsType<ConstructorCallSite>(callSite);
             Assert.Equal(expectedConstructorParameters, GetParameters(constructorCallSite));
         }
@@ -238,7 +238,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         [Theory]
         [MemberData(nameof(CreateCallSite_ConsidersConstructorsWithDefaultValuesData))]
         private void CreateCallSite_ConsidersConstructorsWithDefaultValues(
-            Func<Type, IServiceCallSite> callSiteFactory,
+            Func<Type, ServiceCallSite> callSiteFactory,
             Type[] expectedConstructorParameters)
         {
             // Arrange
@@ -248,7 +248,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             var callSite = callSiteFactory(type);
 
             // Assert
-            Assert.Equal(CallSiteResultCacheLocation.None, callSite.Cache.Location);
+            Assert.Equal(CallSiteResultCacheLocation.Dispose, callSite.Cache.Location);
             var constructorCallSite = Assert.IsType<ConstructorCallSite>(callSite);
             Assert.Equal(expectedConstructorParameters, GetParameters(constructorCallSite));
         }
@@ -400,7 +400,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             Assert.StartsWith(expectedMessage, ex.Message);
         }
 
-        private static Func<Type, IServiceCallSite> GetCallSiteFactory(params ServiceDescriptor[] descriptors)
+        private static Func<Type, ServiceCallSite> GetCallSiteFactory(params ServiceDescriptor[] descriptors)
         {
             var collection = new ServiceCollection();
             foreach (var descriptor in descriptors)

--- a/test/DI.Tests/ServiceProviderCompilationTest.cs
+++ b/test/DI.Tests/ServiceProviderCompilationTest.cs
@@ -1,58 +1,58 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿//// Copyright (c) .NET Foundation. All rights reserved.
+//// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Xunit;
+//using System;
+//using System.Threading;
+//using System.Threading.Tasks;
+//using Xunit;
 
-namespace Microsoft.Extensions.DependencyInjection.Tests
-{
-    public class ServiceProviderCompilationTest
-    {
-        [Theory]
-#if DEBUG
-        [InlineData(ServiceProviderMode.Dynamic, typeof(I150))]
-        [InlineData(ServiceProviderMode.Runtime, typeof(I150))]
-        [InlineData(ServiceProviderMode.ILEmit, typeof(I150))]
-        [InlineData(ServiceProviderMode.Expressions, typeof(I150))]
-#else
-        [InlineData(ServiceProviderMode.Dynamic, typeof(I200))]
-        [InlineData(ServiceProviderMode.Runtime, typeof(I200))]
-        [InlineData(ServiceProviderMode.ILEmit, typeof(I200))]
-        [InlineData(ServiceProviderMode.Expressions, typeof(I200))]
-#endif
-        private async Task CompilesInLimitedStackSpace(ServiceProviderMode mode, Type serviceType)
-        {
-            // Arrange
-            var stackSize = 256 * 1024;
-            var serviceCollection = new ServiceCollection();
-            CompilationTestDataProvider.Register(serviceCollection);
-            var serviceProvider = serviceCollection.BuildServiceProvider(new ServiceProviderOptions { Mode = mode });
+//namespace Microsoft.Extensions.DependencyInjection.Tests
+//{
+//    public class ServiceProviderCompilationTest
+//    {
+//        [Theory]
+//#if DEBUG
+//        [InlineData(ServiceProviderMode.Dynamic, typeof(I150))]
+//        [InlineData(ServiceProviderMode.Runtime, typeof(I150))]
+//        [InlineData(ServiceProviderMode.ILEmit, typeof(I150))]
+//        [InlineData(ServiceProviderMode.Expressions, typeof(I150))]
+//#else
+//        [InlineData(ServiceProviderMode.Dynamic, typeof(I350))]
+//        [InlineData(ServiceProviderMode.Runtime, typeof(I350))]
+//        [InlineData(ServiceProviderMode.ILEmit, typeof(I350))]
+//        [InlineData(ServiceProviderMode.Expressions, typeof(I350))]
+//#endif
+//        private async Task CompilesInLimitedStackSpace(ServiceProviderMode mode, Type serviceType)
+//        {
+//            // Arrange
+//            var stackSize = 256 * 1024;
+//            var serviceCollection = new ServiceCollection();
+//            CompilationTestDataProvider.Register(serviceCollection);
+//            var serviceProvider = serviceCollection.BuildServiceProvider(new ServiceProviderOptions { Mode = mode });
 
-            // Act + Assert
+//            // Act + Assert
 
-            var tsc = new TaskCompletionSource<object>();
-            var thread = new Thread(() =>
-                {
-                    try
-                    {
-                        object service = null;
-                        for (int i = 0; i < 10; i++)
-                        {
-                            service = serviceProvider.GetService(serviceType);
-                        }
-                        tsc.SetResult(service);
-                    }
-                    catch (Exception ex)
-                    {
-                        tsc.SetException(ex);
-                    }
-                }, stackSize);
+//            var tsc = new TaskCompletionSource<object>();
+//            var thread = new Thread(() =>
+//                {
+//                    try
+//                    {
+//                        object service = null;
+//                        for (int i = 0; i < 10; i++)
+//                        {
+//                            service = serviceProvider.GetService(serviceType);
+//                        }
+//                        tsc.SetResult(service);
+//                    }
+//                    catch (Exception ex)
+//                    {
+//                        tsc.SetException(ex);
+//                    }
+//                }, stackSize);
 
-            thread.Start();
-            thread.Join();
-            await tsc.Task;
-        }
-    }
-}
+//            thread.Start();
+//            thread.Join();
+//            await tsc.Task;
+//        }
+//    }
+//}

--- a/test/DI.Tests/ServiceProviderCompilationTest.cs
+++ b/test/DI.Tests/ServiceProviderCompilationTest.cs
@@ -1,58 +1,51 @@
-﻿//// Copyright (c) .NET Foundation. All rights reserved.
-//// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-//using System;
-//using System.Threading;
-//using System.Threading.Tasks;
-//using Xunit;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
 
-//namespace Microsoft.Extensions.DependencyInjection.Tests
-//{
-//    public class ServiceProviderCompilationTest
-//    {
-//        [Theory]
-//#if DEBUG
-//        [InlineData(ServiceProviderMode.Dynamic, typeof(I150))]
-//        [InlineData(ServiceProviderMode.Runtime, typeof(I150))]
-//        [InlineData(ServiceProviderMode.ILEmit, typeof(I150))]
-//        [InlineData(ServiceProviderMode.Expressions, typeof(I150))]
-//#else
-//        [InlineData(ServiceProviderMode.Dynamic, typeof(I350))]
-//        [InlineData(ServiceProviderMode.Runtime, typeof(I350))]
-//        [InlineData(ServiceProviderMode.ILEmit, typeof(I350))]
-//        [InlineData(ServiceProviderMode.Expressions, typeof(I350))]
-//#endif
-//        private async Task CompilesInLimitedStackSpace(ServiceProviderMode mode, Type serviceType)
-//        {
-//            // Arrange
-//            var stackSize = 256 * 1024;
-//            var serviceCollection = new ServiceCollection();
-//            CompilationTestDataProvider.Register(serviceCollection);
-//            var serviceProvider = serviceCollection.BuildServiceProvider(new ServiceProviderOptions { Mode = mode });
+namespace Microsoft.Extensions.DependencyInjection.Tests
+{
+    public class ServiceProviderCompilationTest
+    {
+        [Theory]
+        [InlineData(ServiceProviderMode.Dynamic, typeof(I999))]
+        [InlineData(ServiceProviderMode.Runtime, typeof(I999))]
+        [InlineData(ServiceProviderMode.ILEmit, typeof(I999))]
+        [InlineData(ServiceProviderMode.Expressions, typeof(I999))]
+        private async Task CompilesInLimitedStackSpace(ServiceProviderMode mode, Type serviceType)
+        {
+            // Arrange
+            var stackSize = 256 * 1024;
+            var serviceCollection = new ServiceCollection();
+            CompilationTestDataProvider.Register(serviceCollection);
+            var serviceProvider = serviceCollection.BuildServiceProvider(new ServiceProviderOptions { Mode = mode });
 
-//            // Act + Assert
+            // Act + Assert
 
-//            var tsc = new TaskCompletionSource<object>();
-//            var thread = new Thread(() =>
-//                {
-//                    try
-//                    {
-//                        object service = null;
-//                        for (int i = 0; i < 10; i++)
-//                        {
-//                            service = serviceProvider.GetService(serviceType);
-//                        }
-//                        tsc.SetResult(service);
-//                    }
-//                    catch (Exception ex)
-//                    {
-//                        tsc.SetException(ex);
-//                    }
-//                }, stackSize);
+            var tsc = new TaskCompletionSource<object>();
+            var thread = new Thread(() =>
+                {
+                    try
+                    {
+                        object service = null;
+                        for (int i = 0; i < 10; i++)
+                        {
+                            service = serviceProvider.GetService(serviceType);
+                        }
+                        tsc.SetResult(service);
+                    }
+                    catch (Exception ex)
+                    {
+                        tsc.SetException(ex);
+                    }
+                }, stackSize);
 
-//            thread.Start();
-//            thread.Join();
-//            await tsc.Task;
-//        }
-//    }
-//}
+            thread.Start();
+            thread.Join();
+            await tsc.Task;
+        }
+    }
+}


### PR DESCRIPTION
Changing cache key from `Tuple<CallSite, Type>` allows us:
1. To create callsites non-atomically
2. Remove the global lock in call site factory
3. Add a stack guard that dispatched instead of throwing SO
4. Emit key directly in IL instead of passing reference through

The cache key is changed to `(type, slot)` pair where `type` is service type and `slot` is an index of the item in case it was resolved in `IEnumerable<Type>`

Additional changes:
1. Removed create instance call site - it's just a subset of ConstructorCallSite