### PR TITLE
Lower service tree size for compilation in limited stack tests

### DIFF
--- a/test/DI.Tests/ServiceProviderCompilationTest.cs
+++ b/test/DI.Tests/ServiceProviderCompilationTest.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         [InlineData(ServiceProviderMode.ILEmit, typeof(I150))]
         [InlineData(ServiceProviderMode.Expressions, typeof(I150))]
 #else
-        [InlineData(ServiceProviderMode.Dynamic, typeof(I350))]
-        [InlineData(ServiceProviderMode.Runtime, typeof(I350))]
-        [InlineData(ServiceProviderMode.ILEmit, typeof(I350))]
-        [InlineData(ServiceProviderMode.Expressions, typeof(I350))]
+        [InlineData(ServiceProviderMode.Dynamic, typeof(I200))]
+        [InlineData(ServiceProviderMode.Runtime, typeof(I200))]
+        [InlineData(ServiceProviderMode.ILEmit, typeof(I200))]
+        [InlineData(ServiceProviderMode.Expressions, typeof(I200))]
 #endif
         private async Task CompilesInLimitedStackSpace(ServiceProviderMode mode, Type serviceType)
         {


### PR DESCRIPTION
Fixes: https://github.com/aspnet/Home/issues/3504

Tiered JIT generates larger stack frames so we can handle less deep trees.

https://github.com/aspnet/DependencyInjection/pull/638 is the ultimate fix, until then lower the size.

/cc @davidfowl 