### PR TITLE
Dispose service instances only once

### DIFF
--- a/src/DI.Specification.Tests/DependencyInjectionSpecificationTests.cs
+++ b/src/DI.Specification.Tests/DependencyInjectionSpecificationTests.cs
@@ -742,5 +742,55 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
                 Assert.Equal(service, enumerable[2]);
             }
         }
+
+        [Fact]
+        public void ServicesAreDisposedOnlyOnce_SingletonInRootScope()
+        {
+            // Arrange
+            var collection = new TestServiceCollection();
+            collection.AddSingleton<FakeService>();
+            collection.AddSingleton<IFakeService>(sp => sp.GetService<FakeService>());
+            var provider = CreateServiceProvider(collection);
+
+            // Act & Assert
+            var service = provider.GetService<IFakeService>();
+            var service2 = provider.GetService<FakeService>();
+
+            (provider as IDisposable).Dispose();
+        }
+
+        [Fact]
+        public void ServicesAreDisposedOnlyOnce_ScopedInScope()
+        {
+            // Arrange
+            var collection = new TestServiceCollection();
+            collection.AddScoped<FakeService>();
+            collection.AddScoped<IFakeService>(sp => sp.GetService<FakeService>());
+            var provider = CreateServiceProvider(collection);
+
+            // Act & Assert
+            using (var scope = provider.CreateScope())
+            {
+                var service1 = scope.ServiceProvider.GetService<IFakeService>();
+                var service2 = scope.ServiceProvider.GetService<FakeService>();
+            }
+        }
+
+        [Fact]
+        public void ServicesAreDisposedOnlyOnce_TransientInScope()
+        {
+            // Arrange
+            var collection = new TestServiceCollection();
+            collection.AddTransient<FakeService>();
+            collection.AddTransient<IFakeService>(sp => sp.GetService<FakeService>());
+            var provider = CreateServiceProvider(collection);
+
+            // Act & Assert
+            using (var scope = provider.CreateScope())
+            {
+                var service1 = scope.ServiceProvider.GetService<IFakeService>();
+                var service2 = scope.ServiceProvider.GetService<FakeService>();
+            }
+        }
     }
 }

--- a/src/DI/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/DI/ServiceLookup/ServiceProviderEngineScope.cs
@@ -48,10 +48,12 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 _disposed = true;
                 if (_disposables != null)
                 {
+                    var disposed = new HashSet<IDisposable>();
                     for (var i = _disposables.Count - 1; i >= 0; i--)
                     {
                         var disposable = _disposables[i];
-                        disposable.Dispose();
+                        if (disposed.Add(disposable))
+                            disposable.Dispose();
                     }
 
                     _disposables.Clear();


### PR DESCRIPTION
This is a fix for aspnet/AspNetCore#2932. Unfortunately, just changing the collection to a hash set would not work as #505 requires this to be an ordered collection. So instead, I’m remembering what services I have disposed at the time they get disposed.

An alternative solution would be to have the hash set around as an instance member to avoid *adding* duplicate services to the collection. This would have the benefit that services are disposed in the reversed order of their *first* use. With this fix, they are disposed in the order of their *last* use. Not sure which of those is better; this version at least avoids having a second collection around all the time.